### PR TITLE
C++ header restructured.

### DIFF
--- a/examples/C++/call_cpp_from_js/main.cpp
+++ b/examples/C++/call_cpp_from_js/main.cpp
@@ -6,12 +6,12 @@
 // Include C++ STD
 #include <iostream>
 
-void my_function_string(webui::event* e) {
+void my_function_string(webui::window::event* e) {
 
     // JavaScript:
     // webui_fn('MyID_One', 'Hello');
 
-    std::string str = e->window.get_string(e);
+    std::string str = e->get_string();
     std::cout << "my_function_string: " << str << std::endl; // Hello
 
     // Need Multiple Arguments?
@@ -25,38 +25,38 @@ void my_function_string(webui::event* e) {
     // bar = my_json[1];
 }
 
-void my_function_integer(webui::event* e) {
+void my_function_integer(webui::window::event* e) {
 
     // JavaScript:
     // webui_fn('MyID_Two', 123456789);
 
-    long long number = e->window.get_int(e);
+    long long number = e->get_int();
     std::cout << "my_function_integer: " << number << std::endl; // 123456789
 }
 
-void my_function_boolean(webui::event* e) {
+void my_function_boolean(webui::window::event* e) {
 
     // JavaScript:
     // webui_fn('MyID_Three', true);
 
-    bool status = e->window.get_bool(e); // True
+    bool status = e->get_bool(); // True
     if(status)
         std::cout << "my_function_boolean: True" << std::endl;
     else
         std::cout << "my_function_boolean: False" << std::endl;
 }
 
-void my_function_with_response(webui::event* e) {
+void my_function_with_response(webui::window::event* e) {
 
     // JavaScript:
     // const result = webui_fn('MyID_Four', number);
 
-    long long number = e->window.get_int(e);
+    long long number = e->get_int();
     number = number * 2;
     std::cout << "my_function_with_response: " << number << std::endl;
 
     // Send back the response to JavaScript
-    e->window.return_int(e, number);
+    e->return_int(number);
 }
 
 int main() {

--- a/examples/C++/call_js_from_cpp/main.cpp
+++ b/examples/C++/call_js_from_cpp/main.cpp
@@ -9,13 +9,13 @@
 #include <string>
 #include <stdexcept>
 
-void my_function_exit(webui::event* e) {
+void my_function_exit(webui::window::event* e) {
 
     // Close all opened windows
     webui::exit();
 }
 
-void my_function_count(webui::event* e) {
+void my_function_count(webui::window::event* e) {
 
     // This function gets called every time the user clicks on "MyButton1"
 

--- a/examples/C++/serve_a_folder/main.cpp
+++ b/examples/C++/serve_a_folder/main.cpp
@@ -13,7 +13,7 @@ class MyClass {
 
     // This method gets called every time the
     // user clicks on "OpenNewWindow"
-    void show_second_window(webui::event* e) {
+    void show_second_window(webui::window::event* e) {
 
         // Show a new window, and navigate to `/second.html`
         // if the window is already opened, then switch in the same window
@@ -22,7 +22,7 @@ class MyClass {
 
     // This method gets called every time the
     // user clicks on "SwitchToSecondPage"
-    void switch_to_second_page(webui::event* e) {
+    void switch_to_second_page(webui::window::event* e) {
 
         // Switch to `/second.html` in the same opened window.
         e->window.show("second.html");
@@ -31,7 +31,7 @@ class MyClass {
     // Example of a simple function (Not a method)
     // This function receives all events because
     // it's get bind with an empty HTML ID.
-    void events(webui::event* e) {
+    void events(webui::window::event* e) {
 
         if (e->event_type == webui::CONNECTED)
             std::cout << "Window Connected." << std::endl;
@@ -44,7 +44,7 @@ class MyClass {
     }
 
     // Example of a simple function (Not a method)
-    void exit_app(webui::event* e) {
+    void exit_app(webui::window::event* e) {
 
         // Close all opened windows
         webui::exit();
@@ -56,10 +56,10 @@ class MyClass {
 // access `MyClass` directly. That's why we should
 // create a simple C++ wrapper.
 MyClass obj;
-void show_second_window_wrp(webui::event* e) { obj.show_second_window(e); }
-void switch_to_second_page_wrp(webui::event* e) { obj.switch_to_second_page(e); }
-void events_wrp(webui::event* e) { obj.events(e); }
-void exit_app_wrp(webui::event* e) { obj.exit_app(e); }
+void show_second_window_wrp(webui::window::event* e) { obj.show_second_window(e); }
+void switch_to_second_page_wrp(webui::window::event* e) { obj.switch_to_second_page(e); }
+void events_wrp(webui::window::event* e) { obj.events(e); }
+void exit_app_wrp(webui::window::event* e) { obj.exit_app(e); }
 
 int main() {
 

--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -39,15 +39,13 @@ namespace webui {
     // Event struct
         struct event : public webui_event_t{
             using webui_event_t::webui_event_t;
-            webui::window& window; // The window object
 
             // Window object constructor that
             // initializes the reference, This
             // is to avoid creating copies.
-            event(webui::window& window_obj, webui_event_t c_e = {}) : webui_event_t(c_e),
-                window(window_obj) {
-                    reinterpret_cast<webui_event_t*>(this)->window = window_obj.webui_window;
-                }
+            event(webui::window& window_obj, webui_event_t c_e) : webui_event_t(c_e){
+                reinterpret_cast<webui_event_t*>(this)->window = window_obj.webui_window;
+            }
 
             class handler{
                 public:

--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -14,6 +14,7 @@
 // C++ STD
 #include <string>
 #include <string_view>
+#include <array>
 
 // WebUI C Header
 extern "C" {
@@ -30,180 +31,157 @@ namespace webui {
     const int NAVIGATION = 5; // 5. Window navigation event
     const int CALLBACKS = 6; // 6. Function call event
 
-    class window;
-
-    // Event struct
-    struct event {
-        webui::window& window; // The window object
-        unsigned int event_type; // Event type
-        std::string element; // HTML element ID
-        std::string data; // JavaScript data
-        unsigned int event_number; // Internal WebUI
-
-        // Window object constructor that
-        // initializes the reference, This
-        // is to avoid creating copies.
-        event(webui::window& window_obj) : window(window_obj) {}
-    };
-
-    // List of callbacks: user_function(webui::event* e)
-    void (*callback_list[512])(webui::event*);
-
-    // List of window objects: webui::window
-    webui::window* window_list[512];
-
-    // Event handler
-    // WebUI is written in C. So there is no way
-    // to make C call a C++ class member. That's
-    // why this function should be outside class
-    void event_handler(webui_event_t* c_e) {
-
-        // Get a unique ID. Same ID as `webui_bind()`. Return > 0 if bind exist.
-        unsigned int id = webui_interface_get_bind_id(c_e->window, c_e->element);
-
-        if(id < 1)
-            return;
-
-        // Create a new event struct
-        webui::event e(*window_list[id]);
-        // `e.window` is already initialized by `e` constructor
-        e.event_type = c_e->event_type;
-        e.element = (c_e->element != nullptr ? std::string(c_e->element) : std::string(""));
-        e.data = (c_e->data != nullptr ? std::string(c_e->data) : std::string(""));
-        e.event_number = c_e->event_number;
-
-        // Call the user callback
-        if(callback_list[id] != nullptr)
-            callback_list[id](&e);
-    }
-
     class window {
     private:
-        size_t webui_window = 0;
+        size_t webui_window {webui_new_window()};
 
-        webui_event_t* convert_event_to_webui_event(webui::event* e) const {
-            // Convert C++ `webui::event` to C `webui_event_t`
-            webui_event_t* c_e = new webui_event_t;
-            c_e->window = this->webui_window;
-            c_e->event_type = e->event_type;
-            c_e->element = (char*)e->element.c_str();
-            c_e->data = (char*)e->data.c_str();
-            c_e->event_number = e->event_number;
-            return c_e;
-        }
     public:
-        // Constructor
-        window() : webui_window (webui_new_window()){
-        }
+    // Event struct
+        struct event : public webui_event_t{
+            using webui_event_t::webui_event_t;
+            webui::window& window; // The window object
+
+            // Window object constructor that
+            // initializes the reference, This
+            // is to avoid creating copies.
+            event(webui::window& window_obj, webui_event_t c_e = {}) : webui_event_t(c_e),
+                window(window_obj) {
+                    reinterpret_cast<webui_event_t*>(this)->window = window_obj.webui_window;
+                }
+
+            class handler{
+                public:
+                using callback_t = void(*)(event*);
+
+                private:
+                static inline std::array<callback_t, 512> callback_list{};
+
+                // List of window objects: webui::window
+                static inline std::array<webui::window*, 512> window_list{};
+
+                public:
+                handler() = delete;
+                handler(const handler&) = delete;
+                handler(handler&&) = delete;
+                handler& operator=(const handler&) = delete;
+                handler& operator=(handler&&) = delete;
+                ~handler() = delete;
+
+                static void add(size_t id, webui::window* win, callback_t func){
+                    window_list[id] = win;
+
+                    // Save callback
+                    callback_list[id] = func;
+                }
+
+                static void handle(webui_event_t* c_e) {
+
+                    // Get a unique ID. Same ID as `webui_bind()`. Return > 0 if bind exist.
+                    const size_t id = webui_interface_get_bind_id(c_e->window, c_e->element);
+
+                    if(id < 1){
+                        return;
+                    }
+
+                    // Create a new event struct
+                    event e(*window_list[id], *c_e);
+
+                    // Call the user callback
+                    if(callback_list[id] != nullptr)
+                        callback_list[id](&e);
+                }
+            };
+
+            // Parse argument as integer.
+            long long int get_int()  {
+                return webui_get_int(this);
+            }
+
+            // Parse argument as string.
+            std::string get_string()  {
+                return std::string{webui_get_string(this)};
+            }
+
+            // Parse argument as boolean.
+            bool get_bool()  {
+                return webui_get_bool(this);
+            }
+
+            // Return the response to JavaScript as integer.
+            void return_int(long long int n)  {
+                webui_return_int(this, n);
+            }
+
+            // Return the response to JavaScript as string.
+            void return_string(const std::string_view s)  {
+                webui_return_string(this, s.data());
+            }
+
+            // Return the response to JavaScript as boolean.
+            void return_bool(bool b)  {
+                webui_return_bool(this, b);
+            }
+        };
 
         // Bind a specific html element click event with a function. Empty element means all events.
-        void bind(const std::string_view element, void (*func)(webui::event* e)) {
+        void bind(const std::string_view element, event::handler::callback_t func) {
 
             // Get unique ID
-            unsigned int id = webui_bind(this->webui_window, element.data(), webui::event_handler);
+            const size_t id = webui_bind(webui_window, element.data(), event::handler::handle);
 
-            // Save window object
-            window_list[id] = this;
-
-            // Save callback
-            callback_list[id] = func;
+            event::handler::add(id, this, func);
         }
 
         // Show a window using a embedded HTML, or a file. If the window is already opened then it will be refreshed.
         bool show(const std::string_view content) const {
-            return webui_show(this->webui_window, content.data());
+            return webui_show(webui_window, content.data());
         }
 
         // Same as show(). But with a specific web browser.
         bool show_browser(const std::string_view content, unsigned int browser) const {
-            return webui_show_browser(this->webui_window, content.data(), browser);
+            return webui_show_browser(webui_window, content.data(), browser);
         }
 
         // Close a specific window.
         void close() const {
-            webui_close(this->webui_window);
+            webui_close(webui_window);
         }
 
         // Set the window in Kiosk mode (Full screen)
         void set_kiosk(bool status) const {
-            webui_set_kiosk(this->webui_window, status);
+            webui_set_kiosk(webui_window, status);
         }
 
         // -- Other ---------------------------
         // Check a specific window if it's still running
         bool is_shown() const {
-            return webui_is_shown(this->webui_window);
+            return webui_is_shown(webui_window);
         }
 
         // Set the default embedded HTML favicon
         void set_icon(const std::string_view icon, const std::string& icon_type) const {
-            webui_set_icon(this->webui_window, icon.data(), icon_type.c_str());
+            webui_set_icon(webui_window, icon.data(), icon_type.c_str());
         }
 
         // Allow the window URL to be re-used in normal web browsers
         void set_multi_access(bool status) const {
-            webui_set_multi_access(this->webui_window, status);
+            webui_set_multi_access(webui_window, status);
         }
 
         // -- JavaScript ----------------------
         // Quickly run a JavaScript (no response waiting).
         void run(const std::string_view script) const {
-            webui_run(this->webui_window, script.data());
+            webui_run(webui_window, script.data());
         }
 
         // Run a JavaScript, and get the response back (Make sure your local buffer can hold the response).
         bool script(const std::string_view script, unsigned int timeout, char* buffer, size_t buffer_length) const {
-            return webui_script(this->webui_window, script.data(), timeout, buffer, buffer_length);
+            return webui_script(webui_window, script.data(), timeout, buffer, buffer_length);
         }
 
         // Chose between Deno and Nodejs runtime for .js and .ts files.
         void set_runtime(unsigned int runtime) const {
-            webui_set_runtime(this->webui_window, runtime);
-        }
-
-        // Parse argument as integer.
-        long long int get_int(webui::event* e) const {
-            webui_event_t* c_e = convert_event_to_webui_event(e);
-            long long int ret = webui_get_int(c_e);
-            delete c_e;
-            return ret;
-        }
-
-        // Parse argument as string.
-        std::string get_string(webui::event* e) const {
-            webui_event_t* c_e = convert_event_to_webui_event(e);
-            std::string ret = std::string(webui_get_string(c_e));
-            delete c_e;
-            return ret;
-        }
-
-        // Parse argument as boolean.
-        bool get_bool(webui::event* e) const {
-            webui_event_t* c_e = convert_event_to_webui_event(e);
-            bool ret = webui_get_bool(c_e);
-            delete c_e;
-            return ret;
-        }
-
-        // Return the response to JavaScript as integer.
-        void return_int(webui::event* e, long long int n) const {
-            webui_event_t* c_e = convert_event_to_webui_event(e);
-            webui_return_int(c_e, n);
-            delete c_e;
-        }
-
-        // Return the response to JavaScript as string.
-        void return_string(webui::event* e, const std::string_view s) const {
-            webui_event_t* c_e = convert_event_to_webui_event(e);
-            webui_return_string(c_e, s.data());
-            delete c_e;
-        }
-
-        // Return the response to JavaScript as boolean.
-        void return_bool(webui::event* e, bool b) const {
-            webui_event_t* c_e = convert_event_to_webui_event(e);
-            webui_return_bool(c_e, b);
-            delete c_e;
+            webui_set_runtime(webui_window, runtime);
         }
     };
 


### PR DESCRIPTION
# C++ header restructured.

## Goals of this PR
- Eliminate the need for a conversion function between webui::event and webui_event_t.
- Incapsulate the event handling capabilities in a static class.
- Break the circular dependency between types defined in the C++ header.

## Non-goals of this PR
This PR is only intended to be a code restructuring, and doesn't mean to change how the header achieves the functionality it provides.

## Notes
- These changes slightly change the API, so the example needs to be updated (this PR encapsulates the event struct inside the window class, so to declare an event instance you now need `webui::window::event` instead of `webui::event`).
- This PR is marked as draft because I expect a discussion on these changes, if the changes are well received, I will update the examples.
- These changes have already been tested on Linux using firefox as browser, clang and gcc as compiler, but only with the `serve_folder` example

## Details about the changes

### Eliminate the need for a conversion function between webui::event and webui_event_t.
This is accomplished by making the C++ event struct a derived class of the C struct;
This allows us to use object slicing and pass the C++ struct pointer directly to the C API.
The proposed implementation of the C++ class has two "references" to the window object, one is the `const webui::window&` member, the other is the `webui_event_t.window` member; if the user misuses the API, these two could fall out of sync, turning the `event struct' into a class with the proper gardrails could be the best solution, but is a bit more invasive since it would change the API, so this change isn't currently in this PR.

### Incapsulate the event handling capabilities in a static class.
This change is achieved by encapsulating all free functions and global variables in a static class called handler. There is no particular downside to this.

### Break the circular dependency between types defined in the C++ header.

Once the class that handles the events was created, the circular dependency between the types became apparent, making the implementation literally impossible. 

So the proposed solution is a stronger gerarchy of types. Now the window type encapsulates the event type, which encapsulates the handler type.

As a result of these changes and the removal of the conversion function, the window class had some static members that accepted an `event*` like `get_string(event*)` and `get_bool(event*)`; these members have been moved to the event subclass.