### PR TITLE
C++ header reorganization completed.

### DIFF
--- a/examples/C++/VS2019/serve_a_folder/my_webui_app/webui.hpp
+++ b/examples/C++/VS2019/serve_a_folder/my_webui_app/webui.hpp
@@ -23,13 +23,13 @@ extern "C" {
 
 namespace webui {
 
-    const int DISCONNECTED = 0; // 0. Window disconnection event
-    const int CONNECTED = 1; // 1. Window connection event
-    const int MULTI_CONNECTION = 2; // 2. New window connection event
-    const int UNWANTED_CONNECTION = 3; // 3. New unwanted window connection event
-    const int MOUSE_CLICK = 4; // 4. Mouse click event
-    const int NAVIGATION = 5; // 5. Window navigation event
-    const int CALLBACKS = 6; // 6. Function call event
+    static constexpr int DISCONNECTED = 0; // 0. Window disconnection event
+    static constexpr int CONNECTED = 1; // 1. Window connection event
+    static constexpr int MULTI_CONNECTION = 2; // 2. New window connection event
+    static constexpr int UNWANTED_CONNECTION = 3; // 3. New unwanted window connection event
+    static constexpr int MOUSE_CLICK = 4; // 4. Mouse click event
+    static constexpr int NAVIGATION = 5; // 5. Window navigation event
+    static constexpr int CALLBACKS = 6; // 6. Function call event
 
     class window {
     private:
@@ -39,10 +39,7 @@ namespace webui {
 
     public:
         // Event Struct
-        struct event : public webui_event_t {
-
-            using webui_event_t::webui_event_t;
-
+        class event : public webui_event_t {
             // Window object constructor that
             // initializes the reference, This
             // is to avoid creating copies.
@@ -50,6 +47,7 @@ namespace webui {
 
                 reinterpret_cast<webui_event_t*>(this)->window = window_obj.webui_window;
             }
+            public:
 
             class handler {
 
@@ -110,6 +108,10 @@ namespace webui {
                 return std::string{webui_get_string(this)};
             }
 
+            std::string_view get_string_view()  {
+                return std::string_view{webui_get_string(this)};
+            }
+
             // Parse argument as boolean.
             bool get_bool()  {
                 return webui_get_bool(this);
@@ -132,6 +134,22 @@ namespace webui {
 
             webui::window& get_window(){
                 return event::handler::get_window(window);
+            }
+
+            size_t get_type() const {
+                return event_type;
+            }
+
+            std::string_view get_element() const {
+                return std::string_view{element};
+            }
+
+            std::string_view get_data() const {
+                return std::string_view{data};
+            }
+
+            size_t number() const {
+                return event_number;
             }
         };
 
@@ -171,8 +189,8 @@ namespace webui {
         }
 
         // Set the default embedded HTML favicon
-        void set_icon(const std::string_view icon, const std::string& icon_type) const {
-            webui_set_icon(webui_window, icon.data(), icon_type.c_str());
+        void set_icon(const std::string_view icon, const std::string_view icon_type) const {
+            webui_set_icon(webui_window, icon.data(), icon_type.data());
         }
 
         // Allow the window URL to be re-used in normal web browsers
@@ -214,14 +232,12 @@ namespace webui {
 
     // Base64 encoding. Use this to safely send text based data to the UI. If it fails it will return NULL.
     inline std::string encode(const std::string_view str) {
-        std::string ret = std::string(webui_encode(str.data()));
-        return ret;
+        return std::string{webui_encode(str.data())};
     }
 
     // Base64 decoding. Use this to safely decode received Base64 text from the UI. If it fails it will return NULL.
     inline std::string decode(const std::string_view str) {
-        std::string ret = std::string(webui_decode(str.data()));
-        return ret;
+        return std::string{webui_decode(str.data())};
     }
 
     // Safely free a buffer allocated by WebUI, for example when using webui_encode().

--- a/examples/C++/VS2022/serve_a_folder/my_webui_app/webui.hpp
+++ b/examples/C++/VS2022/serve_a_folder/my_webui_app/webui.hpp
@@ -23,13 +23,13 @@ extern "C" {
 
 namespace webui {
 
-    const int DISCONNECTED = 0; // 0. Window disconnection event
-    const int CONNECTED = 1; // 1. Window connection event
-    const int MULTI_CONNECTION = 2; // 2. New window connection event
-    const int UNWANTED_CONNECTION = 3; // 3. New unwanted window connection event
-    const int MOUSE_CLICK = 4; // 4. Mouse click event
-    const int NAVIGATION = 5; // 5. Window navigation event
-    const int CALLBACKS = 6; // 6. Function call event
+    static constexpr int DISCONNECTED = 0; // 0. Window disconnection event
+    static constexpr int CONNECTED = 1; // 1. Window connection event
+    static constexpr int MULTI_CONNECTION = 2; // 2. New window connection event
+    static constexpr int UNWANTED_CONNECTION = 3; // 3. New unwanted window connection event
+    static constexpr int MOUSE_CLICK = 4; // 4. Mouse click event
+    static constexpr int NAVIGATION = 5; // 5. Window navigation event
+    static constexpr int CALLBACKS = 6; // 6. Function call event
 
     class window {
     private:
@@ -39,10 +39,7 @@ namespace webui {
 
     public:
         // Event Struct
-        struct event : public webui_event_t {
-
-            using webui_event_t::webui_event_t;
-
+        class event : public webui_event_t {
             // Window object constructor that
             // initializes the reference, This
             // is to avoid creating copies.
@@ -50,6 +47,7 @@ namespace webui {
 
                 reinterpret_cast<webui_event_t*>(this)->window = window_obj.webui_window;
             }
+            public:
 
             class handler {
 
@@ -110,6 +108,10 @@ namespace webui {
                 return std::string{webui_get_string(this)};
             }
 
+            std::string_view get_string_view()  {
+                return std::string_view{webui_get_string(this)};
+            }
+
             // Parse argument as boolean.
             bool get_bool()  {
                 return webui_get_bool(this);
@@ -132,6 +134,22 @@ namespace webui {
 
             webui::window& get_window(){
                 return event::handler::get_window(window);
+            }
+
+            size_t get_type() const {
+                return event_type;
+            }
+
+            std::string_view get_element() const {
+                return std::string_view{element};
+            }
+
+            std::string_view get_data() const {
+                return std::string_view{data};
+            }
+
+            size_t number() const {
+                return event_number;
             }
         };
 
@@ -171,8 +189,8 @@ namespace webui {
         }
 
         // Set the default embedded HTML favicon
-        void set_icon(const std::string_view icon, const std::string& icon_type) const {
-            webui_set_icon(webui_window, icon.data(), icon_type.c_str());
+        void set_icon(const std::string_view icon, const std::string_view icon_type) const {
+            webui_set_icon(webui_window, icon.data(), icon_type.data());
         }
 
         // Allow the window URL to be re-used in normal web browsers
@@ -214,14 +232,12 @@ namespace webui {
 
     // Base64 encoding. Use this to safely send text based data to the UI. If it fails it will return NULL.
     inline std::string encode(const std::string_view str) {
-        std::string ret = std::string(webui_encode(str.data()));
-        return ret;
+        return std::string{webui_encode(str.data())};
     }
 
     // Base64 decoding. Use this to safely decode received Base64 text from the UI. If it fails it will return NULL.
     inline std::string decode(const std::string_view str) {
-        std::string ret = std::string(webui_decode(str.data()));
-        return ret;
+        return std::string{webui_decode(str.data())};
     }
 
     // Safely free a buffer allocated by WebUI, for example when using webui_encode().

--- a/examples/C++/call_js_from_cpp/main.cpp
+++ b/examples/C++/call_js_from_cpp/main.cpp
@@ -28,7 +28,7 @@ void my_function_count(webui::window::event* e) {
     //  my_window.script(..., ..., &buffer[0], 64);
 
     // Run JavaScript
-    if(!e->window.script("return GetCount();", 0, response, 64)) {
+    if(!e->get_window().script("return GetCount();", 0, response, 64)) {
 
         std::cout << "JavaScript Error: " << response << std::endl;
         return;
@@ -45,7 +45,7 @@ void my_function_count(webui::window::event* e) {
     js << "SetCount(" << count << ");";
 
     // Run JavaScript (Quick Way)
-    e->window.run(js.str());
+    e->get_window().run(js.str());
 }
 
 int main() {

--- a/examples/C++/serve_a_folder/main.cpp
+++ b/examples/C++/serve_a_folder/main.cpp
@@ -25,7 +25,7 @@ class MyClass {
     void switch_to_second_page(webui::window::event* e) {
 
         // Switch to `/second.html` in the same opened window.
-        e->window.show("second.html");
+        e->get_window().show("second.html");
     }
 
     // Example of a simple function (Not a method)

--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -23,13 +23,13 @@ extern "C" {
 
 namespace webui {
 
-    const int DISCONNECTED = 0; // 0. Window disconnection event
-    const int CONNECTED = 1; // 1. Window connection event
-    const int MULTI_CONNECTION = 2; // 2. New window connection event
-    const int UNWANTED_CONNECTION = 3; // 3. New unwanted window connection event
-    const int MOUSE_CLICK = 4; // 4. Mouse click event
-    const int NAVIGATION = 5; // 5. Window navigation event
-    const int CALLBACKS = 6; // 6. Function call event
+    static constexpr int DISCONNECTED = 0; // 0. Window disconnection event
+    static constexpr int CONNECTED = 1; // 1. Window connection event
+    static constexpr int MULTI_CONNECTION = 2; // 2. New window connection event
+    static constexpr int UNWANTED_CONNECTION = 3; // 3. New unwanted window connection event
+    static constexpr int MOUSE_CLICK = 4; // 4. Mouse click event
+    static constexpr int NAVIGATION = 5; // 5. Window navigation event
+    static constexpr int CALLBACKS = 6; // 6. Function call event
 
     class window {
     private:
@@ -39,10 +39,7 @@ namespace webui {
 
     public:
         // Event Struct
-        struct event : public webui_event_t {
-
-            using webui_event_t::webui_event_t;
-
+        class event : public webui_event_t {
             // Window object constructor that
             // initializes the reference, This
             // is to avoid creating copies.
@@ -50,6 +47,7 @@ namespace webui {
 
                 reinterpret_cast<webui_event_t*>(this)->window = window_obj.webui_window;
             }
+            public:
 
             class handler {
 
@@ -110,6 +108,10 @@ namespace webui {
                 return std::string{webui_get_string(this)};
             }
 
+            std::string_view get_string_view()  {
+                return std::string_view{webui_get_string(this)};
+            }
+
             // Parse argument as boolean.
             bool get_bool()  {
                 return webui_get_bool(this);
@@ -132,6 +134,22 @@ namespace webui {
 
             webui::window& get_window(){
                 return event::handler::get_window(window);
+            }
+
+            size_t get_type() const {
+                return event_type;
+            }
+
+            std::string_view get_element() const {
+                return std::string_view{element};
+            }
+
+            std::string_view get_data() const {
+                return std::string_view{data};
+            }
+
+            size_t number() const {
+                return event_number;
             }
         };
 
@@ -171,8 +189,8 @@ namespace webui {
         }
 
         // Set the default embedded HTML favicon
-        void set_icon(const std::string_view icon, const std::string& icon_type) const {
-            webui_set_icon(webui_window, icon.data(), icon_type.c_str());
+        void set_icon(const std::string_view icon, const std::string_view icon_type) const {
+            webui_set_icon(webui_window, icon.data(), icon_type.data());
         }
 
         // Allow the window URL to be re-used in normal web browsers
@@ -214,14 +232,12 @@ namespace webui {
 
     // Base64 encoding. Use this to safely send text based data to the UI. If it fails it will return NULL.
     inline std::string encode(const std::string_view str) {
-        std::string ret = std::string(webui_encode(str.data()));
-        return ret;
+        return std::string{webui_encode(str.data())};
     }
 
     // Base64 decoding. Use this to safely decode received Base64 text from the UI. If it fails it will return NULL.
     inline std::string decode(const std::string_view str) {
-        std::string ret = std::string(webui_decode(str.data()));
-        return ret;
+        return std::string{webui_decode(str.data())};
     }
 
     // Safely free a buffer allocated by WebUI, for example when using webui_encode().


### PR DESCRIPTION
As the title says, this is the final PR for the C++ header reorganization; now the C++ API should be in a good place, being as fast as the C with OOP in mind.

Main changes in this PR:
- Now event is a class with it's own methods (see [this](https://github.com/webui-dev/webui/pull/106#issuecomment-1563526571))
- Some examples still used `e->window` instead of `e->get_window()` 

All examples are tested and confirmed to work on Linux with Firefox as browser and clang or gcc as compiler.