### PR TITLE
Rename output to `*.tar.gz`

### DIFF
--- a/build/linux_build.sh
+++ b/build/linux_build.sh
@@ -69,10 +69,10 @@ if [ "$ARG1" = "" ]; then
     echo "Compressing the release folder..."
     echo "";
 
-    TAR_OUT="webui-linux-x64-v$WEBUI_VERSION.zip"
+    TAR_OUT="webui-linux-x64-v$WEBUI_VERSION.tar.gz"
     cd "Release"
     sleep 2
-    tar -c -f $TAR_OUT Linux/*
+    tar -czf $TAR_OUT Linux/*
     cd "$RootPath"
 
     echo "";

--- a/build/macos_build.sh
+++ b/build/macos_build.sh
@@ -56,10 +56,10 @@ if [ "$ARG1" = "" ]; then
     echo "Compressing the release folder..."
     echo "";
 
-    TAR_OUT="webui-macos-x64-v$WEBUI_VERSION.zip"
+    TAR_OUT="webui-macos-x64-v$WEBUI_VERSION.tar.gz"
     cd "Release"
     sleep 2
-    tar -c -f $TAR_OUT macOS/*
+    tar -czf $TAR_OUT macOS/*
     cd "$RootPath"
 
     echo "";

--- a/build/windows_build.bat
+++ b/build/windows_build.bat
@@ -91,10 +91,10 @@ IF "%ARG1%"=="" (
     echo.
     echo Compressing the release folder...
 
-    set TAR_OUT=webui-windows-x64-v%WEBUI_VERSION%.zip
+    set TAR_OUT=webui-windows-x64-v%WEBUI_VERSION%.tar.gz
     cd "Release"
     timeout 2 > NUL
-    tar.exe -c -f %TAR_OUT% Windows\*
+    tar.exe -czf %TAR_OUT% Windows\*
     cd "%RootPath%"
 
     echo.


### PR DESCRIPTION
Add compression and output files with extensions which indicate the file type more accurately.

Fixes #120 