### PR TITLE
fix: :bug: webui js API is undefined

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -4480,7 +4480,7 @@ static int _webui_http_handler(struct mg_connection *conn, void *_win) {
                         const char* js = _webui_generate_js_bridge(win);
 
                         // Inject WebUI JS-Bridge into HTML
-                        size_t len = _webui_strlen(win->html) + _webui_strlen(js) + 128;
+                        size_t len = _webui_strlen(win->html) + 128;
                         html = (char*) _webui_malloc(len);
                         if(win->html != NULL && js != NULL) {
                             sprintf(html,

--- a/src/webui.c
+++ b/src/webui.c
@@ -4431,7 +4431,7 @@ static int _webui_http_handler(struct mg_connection *conn, void *_win) {
             // Send
             _webui_http_send(
                 conn, // 200
-                "text/javascript",
+                "application/javascript",
                 js
             );
 
@@ -4484,7 +4484,7 @@ static int _webui_http_handler(struct mg_connection *conn, void *_win) {
                         html = (char*) _webui_malloc(len);
                         if(win->html != NULL && js != NULL) {
                             sprintf(html, 
-                                "%s \n <script type = \"text/javascript\"> \n %s \n </script>",
+                                "%s \n <script type = \"application/javascript\"> \n %s \n </script>",
                                 win->html, js
                             );
                         }

--- a/src/webui.c
+++ b/src/webui.c
@@ -1898,16 +1898,12 @@ static int _webui_serve_file(_webui_window_t* win, struct mg_connection *conn) {
         else {
 
             // 404 - File not exist
-
-            mg_send_http_error(
-                conn, 404,
-                "%s", webui_html_res_not_available
+            _webui_http_send_error_page(
+                conn,
+                webui_html_res_not_available,
+                404
             );
-            // _webui_http_send(
-            //     conn, // 200
-            //     "text/html",
-            //     webui_html_res_not_available
-            // );
+
             http_status_code = 404;
         }
 
@@ -2045,16 +2041,11 @@ static int _webui_interpret_file(_webui_window_t* win, struct mg_connection *con
         if(!_webui_file_exist(full_path)) {
 
             // File not exist - 404
-
-            mg_send_http_error(
-                conn, 404,
-                "%s", webui_html_res_not_available
+            _webui_http_send_error_page(
+                conn,
+                webui_html_res_not_available,
+                404
             );
-            // _webui_http_send(
-            //     conn, // 200
-            //     "text/html",
-            //     webui_html_res_not_available
-            // );
 
             _webui_free_mem((void*)file);
             _webui_free_mem((void*)full_path);
@@ -2104,15 +2095,12 @@ static int _webui_interpret_file(_webui_window_t* win, struct mg_connection *con
 
                 // Deno not installed
 
-                mg_send_http_error(
-                    conn, 500,
-                    "%s", webui_deno_not_found
+                _webui_http_send_error_page(
+                    conn,
+                    webui_deno_not_found,
+                    500
                 );
-                // _webui_http_send(
-                //     conn, // 200
-                //     "text/html",
-                //     webui_deno_not_found
-                // );
+                
                 interpret_http_stat = 500;
             }
         }
@@ -2151,17 +2139,13 @@ static int _webui_interpret_file(_webui_window_t* win, struct mg_connection *con
             }
             else {
 
-                // Node.js not installed
-
-                mg_send_http_error(
-                    conn, 500,
-                    "%s", webui_nodejs_not_found
+                // Node.js not installed                
+                _webui_http_send_error_page(
+                    conn,
+                    webui_nodejs_not_found,
+                    500
                 );
-                // _webui_http_send(
-                //     conn, // 200
-                //     "text/html",
-                //     webui_nodejs_not_found
-                // );
+                
                 interpret_http_stat = 500;
             }
         }
@@ -4368,6 +4352,28 @@ static void _webui_http_send(struct mg_connection *conn, const char* mime_type, 
     );
 }
 
+static void _webui_http_send_error_page(struct mg_connection *conn, const char* body, int status) {
+
+    #ifdef WEBUI_LOG
+        printf("[Core]\t\t_webui_http_send_error_page()...\n");
+    #endif
+
+    // Send header
+    mg_response_header_start(conn, status);
+    mg_response_header_add(conn, "Content-Type", "text/html; charset=utf-8", -1);
+    mg_response_header_add(conn, "Cache-Control", "no-cache, no-store, must-revalidate, private, max-age=0", -1);
+    mg_response_header_add(conn, "Pragma", "no-cache", -1);
+    mg_response_header_add(conn, "Expires", "0", -1);
+    mg_response_header_send(conn);
+
+    // Send body
+    mg_write(
+        conn,
+        body,
+        strlen(body)
+    );
+}
+
 static int _webui_http_log(const struct mg_connection *conn, const char* message) {
 
     #ifdef WEBUI_LOG
@@ -4448,15 +4454,12 @@ static int _webui_http_handler(struct mg_connection *conn, void *_win) {
                         printf("[Core]\t\t_webui_http_handler() -> Embedded Index HTML Already Handled (403)\n");
                     #endif
 
-                    mg_send_http_error(
-                        conn, 403,
-                        "%s", webui_html_served
+                    _webui_http_send_error_page(
+                        conn,
+                        webui_html_served,
+                        403
                     );
-                    // _webui_http_send(
-                    //     conn, // 200
-                    //     "text/html",
-                    //     webui_html_served
-                    // );
+                    
                     http_status_code = 403;
                 }
                 else {

--- a/src/webui_core.h
+++ b/src/webui_core.h
@@ -191,6 +191,7 @@ static void _webui_kill_pid(size_t pid);
 static _webui_window_t* _webui_dereference_win_ptr(void* ptr);
 
 static void _webui_http_send(struct mg_connection *conn, const char* mime_type, const char* body);
+static void _webui_http_send_error_page(struct mg_connection *conn, const char* body, int status);
 static int _webui_http_log(const struct mg_connection *conn, const char* message);
 static int _webui_http_handler(struct mg_connection *conn, void *_win);
 static int _webui_ws_connect_handler(const struct mg_connection *conn, void *_win);


### PR DESCRIPTION
# Issue

![image](https://github.com/webui-dev/webui/assets/58234376/f1c4587b-c486-4ac7-8246-fec4a0b3d9fd)
![image](https://github.com/webui-dev/webui/assets/58234376/71c9af05-2dc6-4503-a2e6-cc040aaf175a)

Since webui script tag is injected after html, any declared js file in the html payload is parsed before the API.
Unless set it "defer" it is executed before the API and cause an error.

I change the html structure order to force js bridge to execute before any user content.
Since bridge is loaded in html head I fix possibly undefined listener that crash the app.

Moreover, since webui.c allow to load js via 2 way (embbeded and via a get url) I choose to the the url way to avoid memory management for future improve and simplify the code (and js was truncated after the changes if I keep string concat approach). In bonus it allow to debug js via the source panel in dev console.

# Improvements

To force top loading I used the auto correct behaviour of html and then construct bad html to load js bridge before all user content (script is loaded just afet <html> tag that is never close, any added user content will be merge after and js result to be in <head>).
This is more an hot fix and need to be improve by inserting the script tag in html head via an XML/DOM parser.