### PR TITLE
allow faster rendering

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -2822,8 +2822,6 @@ static int _webui_get_browser_args(_webui_window_t* win, size_t browser, char *b
 
     const char *chromium_options[] = {
         "--no-first-run",
-        "--disable-gpu",
-        "--disable-software-rasterizer",
         "--no-proxy-server",
         "--safe-mode",
         "--disable-extensions",


### PR DESCRIPTION
After compiling lib with these two flags removed, I have noticed significant improvement in performance of my app.

I understand those two flags are opposite to each other, first one disables GPU rendering and second one disables CPU rendering, my understanding might be wrong, but I don't see a reason to have both of them passed together.