### PR TITLE
Fix CI cache restore for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: latest
       - name: Bundle WebUI Bridge
-        shell: bash
+        if: runner.os != 'Windows'
         run: |
-          pnpm i -g esbuild
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            powershell -command bridge/build.ps1
-          else
-            bridge/build.sh
-          fi
+          npm i -g esbuild
+          bridge/build.sh
+      - name: Bundle WebUI Bridge on Windows
+        if: runner.os == 'Windows'
+        run: bridge/build.ps1
       - uses: actions/cache@v3
         with:
           path: bridge/webui_bridge.h


### PR DESCRIPTION
Either it was a transitory bug with the Cachefile action or it is due to changing the shell for windows.

This PR should fix it. I make sure the change is compatible with the new Makefile in the root directory before marking it as ready.