### PR TITLE
Update table format for supported web browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@
 > 
 > * We are currently writing documentation.
 
+## Contents
+
+- [Features](#features)
+- [Showcase](#showcase)
+- [UI & The Web Technologies](#ui--the-web-technologies)
+- [Documentation](#documentation)
+- [Build](#build)
+- [Examples](#examples)
+- [Supported Languages](#supported-languages)
+- [Supported Web Browsers](#supported-web-browsers)
+- [License](#license)
+
 ## Features
 
 - Written in Pure C
@@ -28,7 +40,7 @@
 - Multi-platform & Multi-Browser
 - Using private profile for safety
 
-## Screenshot
+## Showcase
 
 This [text editor example](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor) is written in C using WebUI as the GUI library. The final executable is portable and has less than _1 MB_ in size (_+html and css files_).
 
@@ -38,7 +50,7 @@ This [text editor example](https://github.com/webui-dev/webui/tree/main/examples
 
 </div>
 
-## CppCon 2019 Presentation
+## UI & The Web Technologies
 
 [Borislav Stanimirov](https://ibob.bg/) discusses using HTML5 in the web browser as GUI at the [C++ Conference 2019 (*YouTube*)](https://www.youtube.com/watch?v=bbbcZd4cuxg).
 
@@ -52,15 +64,13 @@ This [text editor example](https://github.com/webui-dev/webui/tree/main/examples
 
 </div>
 
-## UI & The Web Technologies
-
 Web application UI design is not just about how a product looks but how it works. Using web technologies in your UI makes your product modern and professional, And a well-designed web application will help you make a solid first impression on potential customers. Great web application design also assists you in nurturing leads and increasing conversions. In addition, it makes navigating and using your web app easier for your users.
 
-## Why Use Web Browser?
+### Why Use Web Browser?
 
 Today's web browsers have everything a modern UI needs. Web browsers are very sophisticated and optimized. Therefore, using it as a GUI will be an excellent choice. While old legacy GUI lib is complex and outdated, a WebView-based app is still an option. However, a WebView needs a huge SDK to build and many dependencies to run, and it can only provide some features like a real web browser. That is why WebUI uses real web browsers to give you full features of comprehensive web technologies while keeping your software lightweight and portable.
 
-## How does it work?
+### How Does it Work?
 
 <div align="center">
 
@@ -70,7 +80,7 @@ Today's web browsers have everything a modern UI needs. Web browsers are very so
 
 Think of WebUI like a WebView controller, but instead of embedding the WebView controller in your program, which makes the final program big in size, and non-portable as it needs the WebView runtimes. Instead, by using WebUI, you use a tiny static/dynamic library to run any installed web browser and use it as GUI, which makes your program small, fast, and portable. **All it needs is a web browser**.
 
-## Runtime Dependencies Comparison
+### Runtime Dependencies Comparison
 
 |  | WebView | Qt | WebUI |
 | ------ | ------ | ------ | ------ |
@@ -111,15 +121,20 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
 - [C](https://github.com/webui-dev/webui/tree/main/examples/C)
 - [C++](https://github.com/webui-dev/webui/tree/main/examples/C++)
 
- ## Wrappers
+## Supported Languages
 
-- [Python](https://github.com/webui-dev/python-webui)
-- [TypeScript / JavaScript](https://github.com/webui-dev/deno-webui)
-- [Go](https://github.com/webui-dev/go-webui)
-- [Rust](https://github.com/webui-dev/rust-webui) (*Not Complete*)
-- [V](https://github.com/webui-dev/v-webui)
-- [Nim](https://github.com/webui-dev/nim-webui)
-- [Zig](https://github.com/webui-dev/zig-webui) (*Not Complete*)
+| Language | Status | Link |
+| ------ | ------ | ------ |
+| C/C++ | ✔️ | [WebUI](https://github.com/webui-dev/webui) |
+| | | |
+| **Wrapper Libraries** |
+| Python | ✔️ | [Python-WebUI](https://github.com/webui-dev/python-webui) |
+| TypeScript / JavaScript | ✔️ | [Deno-WebUI](https://github.com/webui-dev/deno-webui) |
+| Go | ✔️ | [Go-WebUI](https://github.com/webui-dev/go-webui) |
+| Rust | *not complete* | [Rust-WebUI](https://github.com/webui-dev/rust-webui) |
+| V | ✔️ | [V-WebUI](https://github.com/webui-dev/v-webui) |
+| Nim | ✔️ | [Nim-WebUI](https://github.com/webui-dev/nim-webui) |
+| Zig | *not complete* | [Zig-WebUI](https://github.com/webui-dev/zig-webui) |
 
 ## Supported Web Browsers
 
@@ -135,19 +150,6 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
 | Epic | ✔️ | ✔️ | *not available* |
 | Apple Safari | *not available* | *coming soon* | *not available* |
 | Opera | *coming soon* | *coming soon* | *coming soon* |
-
-## Supported Languages
-
-| Language | Status | Link |
-| ------ | ------ | ------ |
-| C/C++ | ✔️ | [WebUI](https://github.com/webui-dev/webui) |
-| Python | ✔️ | [Python-WebUI](https://github.com/webui-dev/python-webui) |
-| TypeScript / JavaScript | ✔️ | [Deno-WebUI](https://github.com/webui-dev/deno-webui) |
-| Go | ✔️ | [Go-WebUI](https://github.com/webui-dev/go-webui) |
-| Rust | *Not Complete* | [Rust-WebUI](https://github.com/webui-dev/rust-webui) |
-| V | ✔️ | [V-WebUI](https://github.com/webui-dev/v-webui) |
-| Nim | ✔️ | [Nim-WebUI](https://github.com/webui-dev/nim-webui) |
-| Zig | *Not Complete* | [Zig-WebUI](https://github.com/webui-dev/zig-webui) |
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [Documentation](#documentation)
 - [Build](#build)
 - [Examples](#examples)
-- [Supported Languages](#supported-languages)
+- [Wrappers](#wrappers)
 - [Supported Web Browsers](#supported-web-browsers)
 - [License](#license)
 
@@ -99,8 +99,10 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
   ```powershell
   # GCC
   mingw32-make
+  
   # TCC
   mingw32-make COMPILER=tcc
+  
   # MSVC
   nmake
   ```
@@ -108,6 +110,7 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
   ```sh
   # GCC
   make
+  
   # Clang
   make COMPILER=clang
   ```
@@ -121,13 +124,10 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
 - [C](https://github.com/webui-dev/webui/tree/main/examples/C)
 - [C++](https://github.com/webui-dev/webui/tree/main/examples/C++)
 
-## Supported Languages
+## Wrappers
 
 | Language | Status | Link |
 | ------ | ------ | ------ |
-| C/C++ | ✔️ | [WebUI](https://github.com/webui-dev/webui) |
-| | | |
-| **Wrapper Libraries** |
 | Python | ✔️ | [Python-WebUI](https://github.com/webui-dev/python-webui) |
 | TypeScript / JavaScript | ✔️ | [Deno-WebUI](https://github.com/webui-dev/deno-webui) |
 | Go | ✔️ | [Go-WebUI](https://github.com/webui-dev/go-webui) |

--- a/README.md
+++ b/README.md
@@ -108,53 +108,33 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
 
 ## Examples
 
- - [C](https://github.com/webui-dev/webui/tree/main/examples/C)
- - [C++](https://github.com/webui-dev/webui/tree/main/examples/C++)
+- [C](https://github.com/webui-dev/webui/tree/main/examples/C)
+- [C++](https://github.com/webui-dev/webui/tree/main/examples/C++)
 
  ## Wrappers
 
- - [Python](https://github.com/webui-dev/python-webui)
- - [TypeScript / JavaScript](https://github.com/webui-dev/deno-webui)
- - [Go](https://github.com/webui-dev/go-webui)
- - [Rust](https://github.com/webui-dev/rust-webui) (*Not Complete*)
- - [V](https://github.com/webui-dev/v-webui)
- - [Nim](https://github.com/webui-dev/nim-webui)
- - [Zig](https://github.com/webui-dev/zig-webui) (*Not Complete*)
+- [Python](https://github.com/webui-dev/python-webui)
+- [TypeScript / JavaScript](https://github.com/webui-dev/deno-webui)
+- [Go](https://github.com/webui-dev/go-webui)
+- [Rust](https://github.com/webui-dev/rust-webui) (*Not Complete*)
+- [V](https://github.com/webui-dev/v-webui)
+- [Nim](https://github.com/webui-dev/nim-webui)
+- [Zig](https://github.com/webui-dev/zig-webui) (*Not Complete*)
 
 ## Supported Web Browsers
 
-| OS | Browser | Status |
-| ------ | ------ | ------ |
-| Windows | Mozilla Firefox | ✔️ |
-| Windows | Google Chrome | ✔️ |
-| Windows | Microsoft Edge | ✔️ |
-| Windows | Chromium | ✔️ |
-| Windows | Yandex | ✔️ |
-| Windows | Brave | ✔️ |
-| Windows | Vivaldi | ✔️ |
-| Windows | Epic | ✔️ |
-| Windows | Opera | *coming soon* |
-| - | - | - |
-| Linux | Mozilla Firefox | ✔️ |
-| Linux | Google Chrome | ✔️ |
-| Linux | Microsoft Edge | ✔️ |
-| Linux | Chromium | ✔️ |
-| Linux | Yandex | ✔️ |
-| Linux | Brave | ✔️ |
-| Linux | Vivaldi | ✔️ |
-| Linux | Epic | *Does Not Exist* |
-| Linux | Opera | *coming soon* |
-| - | - | - |
-| macOS | Mozilla Firefox | ✔️ |
-| macOS | Google Chrome | ✔️ |
-| macOS | Microsoft Edge | ✔️ |
-| macOS | Chromium | ✔️ |
-| macOS | Yandex | ✔️ |
-| macOS | Brave | ✔️ |
-| macOS | Vivaldi | ✔️ |
-| macOS | Epic | ✔️ |
-| macOS | Apple Safari | *coming soon* |
-| macOS | Opera | *coming soon* |
+| Browser | Windows | macOS | Linux |
+| ------ | ------ | ------ | ------ |
+| Mozilla Firefox | ✔️ | ✔️ | ✔️ |
+| Google Chrome | ✔️ | ✔️ | ✔️ |
+| Microsoft Edge | ✔️ | ✔️ | ✔️ |
+| Chromium | ✔️ | ✔️ | ✔️ |
+| Yandex | ✔️ | ✔️ | ✔️ |
+| Brave | ✔️ | ✔️ | ✔️ |
+| Vivaldi | ✔️ | ✔️ | ✔️ |
+| Epic | ✔️ | ✔️ | *not available* |
+| Apple Safari | *not available* | *coming soon* | *not available* |
+| Opera | *coming soon* | *coming soon* | *coming soon* |
 
 ## Supported Languages
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
   mingw32-make COMPILER=tcc
   
   # MSVC
-  nmake
+  nmake -f Makefile.nmake
   ```
 - **Linux**
   ```sh

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This [text editor example](https://github.com/webui-dev/webui/tree/main/examples
 
 Web application UI design is not just about how a product looks but how it works. Using web technologies in your UI makes your product modern and professional, And a well-designed web application will help you make a solid first impression on potential customers. Great web application design also assists you in nurturing leads and increasing conversions. In addition, it makes navigating and using your web app easier for your users.
 
-### Why Use Web Browser?
+### Why Use Web Browsers?
 
 Today's web browsers have everything a modern UI needs. Web browsers are very sophisticated and optimized. Therefore, using it as a GUI will be an excellent choice. While old legacy GUI lib is complex and outdated, a WebView-based app is still an option. However, a WebView needs a huge SDK to build and many dependencies to run, and it can only provide some features like a real web browser. That is why WebUI uses real web browsers to give you full features of comprehensive web technologies while keeping your software lightweight and portable.
 


### PR DESCRIPTION
- Updates formatting for the table of supported web browsers
  current: https://github.com/webui-dev/webui#supported-web-browsers
  suggested: https://github.com/ttytm/webui/tree/docs/format#supported-web-browsers
- Removes first indent level whitespace for a list to e.g. match the formatting for the `Feature section

What do you think of adding a table of contents on top of the Readme for quick navigation? Kind of like here: https://github.com/ttytm/wthrr-the-weathercrab#-wthrr-the-weathercrab

Just above the `Features` section.