### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    paths-ignore: ['**/*.md']
+  pull_request:
+    branches: [main]
+    paths-ignore: ['**/*.md']
+
+jobs:
+  windows:
+    uses: ./.github/workflows/windows.yml
+    permissions:
+      contents: write
+
+  macos:
+    uses: ./.github/workflows/macos.yml
+    permissions:
+      contents: write
+
+  linux:
+    uses: ./.github/workflows/linux.yml
+    permissions:
+      contents: write

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,57 @@
+name: Linux
+on:
+  workflow_call:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bundle WebUI Bridge
+        run: |
+          npm i -g esbuild
+          bridge/build.sh
+      - uses: actions/cache@v3
+        with:
+          path: bridge/webui_bridge.h
+          key: ${{ runner.os }}-${{ github.sha }}-bridge
+
+  build-release:
+    needs: setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        compiler: [GCC, Clang]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache/restore@v3
+        with:
+          path: bridge/webui_bridge.h
+          key: ${{ runner.os }}-${{ github.sha }}-bridge
+          fail-on-cache-miss: true
+      - name: Build
+        run: |
+          if [ "${{ matrix.compiler }}" == "Clang" ]; then
+            sudo ln -s llvm-ar-13 /usr/bin/llvm-ar
+            sudo ln -s llvm-ranlib-13 /usr/bin/llvm-ranlib
+          fi
+          make
+      - name: Prepare Artifact
+        run: |
+          cp -r include dist
+          artifact=${{ runner.os }}-${{ matrix.compiler }}-x64
+          # Add the ARTIFACT name(`,,` ^= lowercase shell param) as GitHub environment variable.
+          echo "ARTIFACT=${artifact,,}" >> $GITHUB_ENV
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: dist
+      - name: Release Artifact
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.ARTIFACT }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,20 +38,25 @@ jobs:
             sudo ln -s llvm-ar-13 /usr/bin/llvm-ar
             sudo ln -s llvm-ranlib-13 /usr/bin/llvm-ranlib
           fi
-          make
+          compiler=${{ matrix.compiler }}
+          make COMPILER=${compiler,,}
       - name: Prepare Artifact
         run: |
           cp -r include dist
           artifact=${{ runner.os }}-${{ matrix.compiler }}-x64
-          # Add the ARTIFACT name(`,,` ^= lowercase shell param) as GitHub environment variable.
-          echo "ARTIFACT=${artifact,,}" >> $GITHUB_ENV
+          # Convert to lowercase (`,,` ^= lowercase shell param)
+          artifact=${artifact,,}
+          # Add the ARTIFACT name as GitHub environment variable.
+          echo "ARTIFACT=$artifact" >> $GITHUB_ENV
+          mv dist/ $artifact
+          tar -czvf $artifact.tar.gz $artifact
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
-          path: dist
+          path: ${{ env.ARTIFACT }}
       - name: Release Artifact
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.ARTIFACT }}
+          files: ${{ env.ARTIFACT }}.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Prepare Artifact
         run: |
           cp -r include dist
-          artifact=${{ runner.os }}-${{ matrix.compiler }}-x64
+          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}-x64
           # Convert to lowercase (`,,` ^= lowercase shell param)
           artifact=${artifact,,}
           # Add the ARTIFACT name as GitHub environment variable.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         compiler: [Clang]
+        arch: [x64, arm]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache/restore@v3
@@ -33,20 +34,26 @@ jobs:
           fail-on-cache-miss: true
       - name: Build
         run: |
-          make
+          if [ "${{ matrix.arch }}" == "arm" ]; then
+            make ARCH_TARGET="-target arm64-apple-darwin"
+          else
+            make
+          fi
       - name: Prepare Artifacts
         run: |
           cp -r include dist
           # Add the ARTIFACT name(lowercased) as GitHub environment variable.
-          artifact=$(echo ${{ runner.os }}-${{ matrix.compiler }}-x64 | tr '[:upper:]' '[:lower:]')
+          artifact=$(echo ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
+          mv dist/ $artifact
+          tar -czvf $artifact.tar.gz $artifact
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
-          path: dist
+          path: ${{ env.ARTIFACT }}
       - name: Release Artifact
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.ARTIFACT }}
+          files: ${{ env.ARTIFACT }}.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,52 @@
+name: macOS
+on:
+  workflow_call:
+
+jobs:
+  setup:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bundle WebUI Bridge
+        run: |
+          npm i -g esbuild
+          bridge/build.sh
+      - uses: actions/cache@v3
+        with:
+          path: bridge/webui_bridge.h
+          key: ${{ runner.os }}-${{ github.sha }}-bridge
+
+  build-release:
+    needs: setup
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        compiler: [Clang]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache/restore@v3
+        with:
+          path: bridge/webui_bridge.h
+          key: ${{ runner.os }}-${{ github.sha }}-bridge
+          fail-on-cache-miss: true
+      - name: Build
+        run: |
+          make
+      - name: Prepare Artifacts
+        run: |
+          cp -r include dist
+          # Add the ARTIFACT name(lowercased) as GitHub environment variable.
+          artifact=$(echo ${{ runner.os }}-${{ matrix.compiler }}-x64 | tr '[:upper:]' '[:lower:]')
+          echo "ARTIFACT=$artifact" >> $GITHUB_ENV
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: dist
+      - name: Release Artifact
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.ARTIFACT }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         compiler: [Clang]
-        arch: [x64, arm]
+        arch: [x64, arm64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache/restore@v3
@@ -34,7 +34,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Build
         run: |
-          if [ "${{ matrix.arch }}" == "arm" ]; then
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
             make ARCH_TARGET="-target arm64-apple-darwin"
           else
             make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,15 +46,19 @@ jobs:
         run: |
           cp -r include dist
           artifact=${{ runner.os }}-${{ matrix.compiler }}-x64
-          # Add the ARTIFACT name(`,,` ^= lowercase shell param) as GitHub environment variable.
-          echo "ARTIFACT=${artifact,,}" >> $GITHUB_ENV
+          # Convert to lowercase (`,,` ^= lowercase shell param)
+          artifact=${artifact,,}
+          # Add the ARTIFACT name as GitHub environment variable.
+          echo "ARTIFACT=$artifact" >> $GITHUB_ENV
+          mv dist/ $artifact
+          7z a -tzip $artifact.zip $artifact
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
-          path: dist
+          path: ${{ env.ARTIFACT }}
       - name: Release Artifact
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.ARTIFACT }}
+          files: ${{ env.ARTIFACT }}.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build
         run: |
-          mkdir dist
           if ('${{ matrix.compiler }}' -eq 'MSVC') {
             nmake -f ./Makefile.nmake
           } else {
@@ -45,7 +44,7 @@ jobs:
         shell: bash
         run: |
           cp -r include dist
-          artifact=${{ runner.os }}-${{ matrix.compiler }}-x64
+          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}-x64
           # Convert to lowercase (`,,` ^= lowercase shell param)
           artifact=${artifact,,}
           # Add the ARTIFACT name as GitHub environment variable.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,60 @@
+name: Windows
+on:
+  workflow_call:
+
+jobs:
+  setup:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bundle WebUI Bridge
+        run: bridge/build.ps1
+      - uses: actions/cache@v3
+        with:
+          path: bridge/webui_bridge.h
+          key: ${{ runner.os }}-${{ github.sha }}-bridge
+
+  build-release:
+    needs: setup
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        compiler: [GCC, MSVC]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache/restore@v3
+        with:
+          path: bridge/webui_bridge.h
+          key: ${{ runner.os }}-${{ github.sha }}-bridge
+          fail-on-cache-miss: true
+      - uses: microsoft/setup-msbuild@v1.1
+      - if: ${{ matrix.compiler == 'MSVC' }}
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Build
+        run: |
+          mkdir dist
+          if ('${{ matrix.compiler }}' -eq 'MSVC') {
+            nmake -f ./Makefile.nmake
+          } else {
+            mingw32-make
+          }
+      - name: Prepare Artifact
+        shell: bash
+        run: |
+          cp -r include dist
+          artifact=${{ runner.os }}-${{ matrix.compiler }}-x64
+          # Add the ARTIFACT name(`,,` ^= lowercase shell param) as GitHub environment variable.
+          echo "ARTIFACT=${artifact,,}" >> $GITHUB_ENV
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: dist
+      - name: Release Artifact
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.ARTIFACT }}

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,9 @@ ifneq ($(filter $(COMPILER),$(VALID_COMPILERS)),$(COMPILER))
 endif
 # Arch target is for CI cross-compilation
 ifneq ($(ARCH_TARGET),)
-	ifneq ($(PLATFORM),macos)
-		$(error ARCH_TARGET is only available on macOS)
-	else ifeq ($(ARCH_TARGET),arm64-apple-darwin)
-		ARCH_TARGET := -target $(ARCH_TARGET)
-	endif
+ifneq ($(PLATFORM),macos)
+	$(error ARCH_TARGET is only available on macOS)
+endif
 endif
 
 # == 2.1.1 GCC / CLANG ========================================================

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@ WEBUI_BUILD_FLAGS := -m64 -o webui.o -I "$(MAKEFILE_DIR)/include/" -c "$(MAKEFIL
 # Output files
 # The static output is the same for all platforms
 # The dynamic output is platform dependent
-LIB_STATIC_OUT := libwebui-2-static-x64.a
+LIB_STATIC_OUT := libwebui-2-static.a
 
 # Platform defaults and dynamic library outputs
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
 	VALID_COMPILERS := gcc tcc
-	LIB_DYN_OUT := webui-2-x64.dll
+	LIB_DYN_OUT := webui-2.dll
 	LWS2_OPT := -lws2_32
 	ifeq ($(COMPILER),tcc)
 		BUILD_TARGET := --tcc
@@ -41,7 +41,7 @@ else
 		# MacOS
 		PLATFORM := macos
 		VALID_COMPILERS := clang
-		LIB_DYN_OUT := webui-2-x64.dylib
+		LIB_DYN_OUT := webui-2.dylib
 		ifeq ($(COMPILER),)
 			COMPILER = clang
 		endif
@@ -49,7 +49,7 @@ else
 		# Linux
 		PLATFORM := linux
 		VALID_COMPILERS := gcc clang
-		LIB_DYN_OUT := webui-2-x64.so
+		LIB_DYN_OUT := webui-2.so
 		ifeq ($(COMPILER),)
 			COMPILER = gcc
 		else ifeq ($(COMPILER),clang)
@@ -87,6 +87,8 @@ ifneq ($(ARCH_TARGET),)
 ifneq ($(PLATFORM),macos)
 	$(error ARCH_TARGET is only available on macOS)
 endif
+# WARN: Wrong input is not covered yet due to difficulties with differing behavior on Mac
+# ARCH_TARGET is intented for CI use. Valid input is `ARCH_TARGET="-target arm64-apple-darwin"`.
 endif
 
 # == 2.1.1 GCC / CLANG ========================================================

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -13,8 +13,8 @@ CIVETWEB_DEFINE_FLAGS = -DNDEBUG -DNO_CACHING -DNO_CGI -DNO_SSL -DUSE_WEBSOCKET
 WEBUI_BUILD_FLAGS = /Fo$(BUILD_DIR)webui.obj /c /EHsc "$(MAKEFILE_DIR)/src/webui.c" /I "$(MAKEFILE_DIR)include"
 
 # Output Commands
-LIB_STATIC_OUT = /OUT:$(BUILD_DIR)webui-2-static-x64.lib $(BUILD_DIR)webui.obj $(BUILD_DIR)civetweb.obj
-LIB_DYN_OUT = /DLL /OUT:$(BUILD_DIR)webui-2-x64.dll $(BUILD_DIR)webui.obj $(BUILD_DIR)civetweb.obj user32.lib Advapi32.lib
+LIB_STATIC_OUT = /OUT:$(BUILD_DIR)webui-2-static.lib $(BUILD_DIR)webui.obj $(BUILD_DIR)civetweb.obj
+LIB_DYN_OUT = /DLL /OUT:$(BUILD_DIR)webui-2.dll $(BUILD_DIR)webui.obj $(BUILD_DIR)civetweb.obj user32.lib Advapi32.lib
 
 # == 2.TARGETS ================================================================
 

--- a/examples/C++/call_cpp_from_js/Linux/Clang/Makefile
+++ b/examples/C++/call_cpp_from_js/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/call_cpp_from_js/Linux/GCC/Makefile
+++ b/examples/C++/call_cpp_from_js/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/call_cpp_from_js/Windows/GCC/Makefile
+++ b/examples/C++/call_cpp_from_js/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C++/call_cpp_from_js/Windows/MSVC/Makefile
+++ b/examples/C++/call_cpp_from_js/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C++/call_cpp_from_js/Windows/TCC/Makefile
+++ b/examples/C++/call_cpp_from_js/Windows/TCC/Makefile
@@ -12,10 +12,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1
@@ -24,10 +24,10 @@ debug:
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
-	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
-	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1

--- a/examples/C++/call_cpp_from_js/macOS/Clang/Makefile
+++ b/examples/C++/call_cpp_from_js/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C++/call_js_from_cpp/Linux/Clang/Makefile
+++ b/examples/C++/call_js_from_cpp/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/call_js_from_cpp/Linux/GCC/Makefile
+++ b/examples/C++/call_js_from_cpp/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/call_js_from_cpp/Windows/GCC/Makefile
+++ b/examples/C++/call_js_from_cpp/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C++/call_js_from_cpp/Windows/MSVC/Makefile
+++ b/examples/C++/call_js_from_cpp/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C++/call_js_from_cpp/Windows/TCC/Makefile
+++ b/examples/C++/call_js_from_cpp/Windows/TCC/Makefile
@@ -12,10 +12,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1
@@ -24,10 +24,10 @@ debug:
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
-	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
-	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1

--- a/examples/C++/call_js_from_cpp/macOS/Clang/Makefile
+++ b/examples/C++/call_js_from_cpp/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C++/minimal/Linux/Clang/Makefile
+++ b/examples/C++/minimal/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/minimal/Linux/GCC/Makefile
+++ b/examples/C++/minimal/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/minimal/Windows/GCC/Makefile
+++ b/examples/C++/minimal/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C++/minimal/Windows/MSVC/Makefile
+++ b/examples/C++/minimal/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C++/minimal/macOS/Clang/Makefile
+++ b/examples/C++/minimal/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C++/serve_a_folder/Linux/Clang/Makefile
+++ b/examples/C++/serve_a_folder/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/serve_a_folder/Linux/GCC/Makefile
+++ b/examples/C++/serve_a_folder/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@g++ -std=c++17 -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@g++ -std=c++17 -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C++/serve_a_folder/Windows/GCC/Makefile
+++ b/examples/C++/serve_a_folder/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -static -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@g++ -std=c++17 -g -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -static -Os -m64 -o main.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@windres win.rc -O coff -o win.res
-	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@g++ -std=c++17 -m64 -o main-dyn.exe "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C++/serve_a_folder/Windows/MSVC/Makefile
+++ b/examples/C++/serve_a_folder/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C++/serve_a_folder/macOS/Clang/Makefile
+++ b/examples/C++/serve_a_folder/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
-	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
-	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C++ Example (Static Release)..."
-	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
-	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C/call_c_from_js/Linux/Clang/Makefile
+++ b/examples/C/call_c_from_js/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/call_c_from_js/Linux/GCC/Makefile
+++ b/examples/C/call_c_from_js/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/call_c_from_js/Windows/GCC/Makefile
+++ b/examples/C/call_c_from_js/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C/call_c_from_js/Windows/MSVC/Makefile
+++ b/examples/C/call_c_from_js/Windows/MSVC/Makefile
@@ -13,21 +13,21 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C/call_c_from_js/Windows/TCC/Makefile
+++ b/examples/C/call_c_from_js/Windows/TCC/Makefile
@@ -12,10 +12,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1
@@ -24,10 +24,10 @@ debug:
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
-	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
-	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1

--- a/examples/C/call_c_from_js/macOS/Clang/Makefile
+++ b/examples/C/call_c_from_js/macOS/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 # Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 # Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
 # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -23,10 +23,10 @@ debug:
 release:
 # Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 # Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
 # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C/call_js_from_c/Linux/Clang/Makefile
+++ b/examples/C/call_js_from_c/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/call_js_from_c/Linux/GCC/Makefile
+++ b/examples/C/call_js_from_c/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/call_js_from_c/Windows/GCC/Makefile
+++ b/examples/C/call_js_from_c/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C/call_js_from_c/Windows/MSVC/Makefile
+++ b/examples/C/call_js_from_c/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C/call_js_from_c/Windows/TCC/Makefile
+++ b/examples/C/call_js_from_c/Windows/TCC/Makefile
@@ -12,10 +12,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1
@@ -24,10 +24,10 @@ debug:
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
-	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
-	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1

--- a/examples/C/call_js_from_c/macOS/Clang/Makefile
+++ b/examples/C/call_js_from_c/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C/minimal/Linux/Clang/Makefile
+++ b/examples/C/minimal/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/minimal/Linux/GCC/Makefile
+++ b/examples/C/minimal/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/minimal/Windows/GCC/Makefile
+++ b/examples/C/minimal/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C/minimal/Windows/MSVC/Makefile
+++ b/examples/C/minimal/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C/minimal/Windows/TCC/Makefile
+++ b/examples/C/minimal/Windows/TCC/Makefile
@@ -12,10 +12,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1
@@ -24,10 +24,10 @@ debug:
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
-	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
-	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1

--- a/examples/C/minimal/macOS/Clang/Makefile
+++ b/examples/C/minimal/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C/serve_a_folder/Linux/Clang/Makefile
+++ b/examples/C/serve_a_folder/Linux/Clang/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@llvm-strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@llvm-strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/serve_a_folder/Linux/GCC/Makefile
+++ b/examples/C/serve_a_folder/Linux/GCC/Makefile
@@ -11,10 +11,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 #	Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 #	Clean
 	@- rm -f *.o
 	@echo "Done."
@@ -22,11 +22,11 @@ debug:
 release:
 #	Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@gcc -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
 	@strip --strip-all main
 #	Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.so" -lpthread -lm
+	@gcc -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.so" -lpthread -lm
 	@strip --strip-all main-dyn
 #	Clean
 	@- rm -f *.o

--- a/examples/C/serve_a_folder/Windows/GCC/Makefile
+++ b/examples/C/serve_a_folder/Windows/GCC/Makefile
@@ -13,11 +13,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -static -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@windres win.rc -O coff -o win.res
-	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
+	@gcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.res >nul 2>&1
@@ -27,12 +27,12 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static-x64 -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -static -Os -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main.exe
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@windres win.rc -O coff -o win.res
-	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2-x64.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
+	@gcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" win.res "$(LIB)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=windows -luser32
 	@strip --strip-all main-dyn.exe
 #	Clean
 	@- del *.o >nul 2>&1

--- a/examples/C/serve_a_folder/Windows/MSVC/Makefile
+++ b/examples/C/serve_a_folder/Windows/MSVC/Makefile
@@ -15,11 +15,11 @@ debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
 	@rc win.rc 1>NUL 2>&1
-	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
 #	Build Lib
@@ -27,11 +27,11 @@ release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static-x64.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
 	@rc win.rc 1>NUL 2>&1
-	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-x64.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
 	@- del *.res >nul 2>&1
 	@- del *.obj >nul 2>&1

--- a/examples/C/serve_a_folder/Windows/TCC/Makefile
+++ b/examples/C/serve_a_folder/Windows/TCC/Makefile
@@ -12,10 +12,10 @@ all: release
 debug:
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
+	@tcc -g -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=console -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1
@@ -24,10 +24,10 @@ debug:
 release:
 #	Static Release
 	@echo Build C99 Example (Static Release)...
-	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Dynamic Release
 	@echo Build C99 Example (Dynamic Release)...
-	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
+	@tcc -m64 -o main-dyn.exe "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.def" -lws2_32 -lAdvapi32 -Wall -Wl,-subsystem=windows -w -luser32
 #	Clean
 	@- del *.o >nul 2>&1
 	@- del *.def >nul 2>&1

--- a/examples/C/serve_a_folder/macOS/Clang/Makefile
+++ b/examples/C/serve_a_folder/macOS/Clang/Makefile
@@ -13,10 +13,10 @@ debug:
 	@cd "$(LIB)" && $(MAKE) debug
     # Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
-	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
-	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
@@ -27,10 +27,10 @@ release:
 	@cd "$(LIB)" && $(MAKE)
     # Static Release
 	@echo "Build C99 Example (Static Release)..."
-	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static-x64 -lpthread -lm
+	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
     # Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
-	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2-x64.dyn" -lpthread -lm
+	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
     # Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM

--- a/examples/C/text-editor/README.md
+++ b/examples/C/text-editor/README.md
@@ -11,5 +11,5 @@ This [text editor example](https://github.com/webui-dev/webui/tree/main/examples
 ```sh
 git clone https://github.com/webui-dev/webui.git
 cd webui\examples\C\text-editor
-gcc -o text-editor.exe text-editor.c webui-2-x64.dll -Wl,-subsystem=windows -lcomdlg32
+gcc -o text-editor.exe text-editor.c webui-2.dll -Wl,-subsystem=windows -lcomdlg32
 ```

--- a/src/civetweb/civetweb.c
+++ b/src/civetweb/civetweb.c
@@ -592,13 +592,13 @@ typedef const char *SOCK_OPT_TYPE;
 #if !defined(SSL_LIB)
 
 #if defined(OPENSSL_API_3_0)
-#define SSL_LIB "libssl-3-x64.dll"
-#define CRYPTO_LIB "libcrypto-3-x64.dll"
+#define SSL_LIB "libssl-3.dll"
+#define CRYPTO_LIB "libcrypto-3.dll"
 #endif
 
 #if defined(OPENSSL_API_1_1)
-#define SSL_LIB "libssl-1_1-x64.dll"
-#define CRYPTO_LIB "libcrypto-1_1-x64.dll"
+#define SSL_LIB "libssl-1_1.dll"
+#define CRYPTO_LIB "libcrypto-1_1.dll"
 #endif /* OPENSSL_API_1_1 */
 
 #if defined(OPENSSL_API_1_0)


### PR DESCRIPTION
This is a workflow strategy I developed and started to incorporate into several projects recently.

It splits the platform workflows into their dedicated files. Through using callable workflows and triggering them from one master CI file it keeps all jobs organized in one Workflow and visualizes it nicely. 

This is what it would result in:
https://github.com/ttytm/webui/actions/runs/5930971332

The change comes with a little performance benefit as the setup jobs are split and consecutive jobs don't need to wait for all platforms to be setup. Another little benefit from this is that when  changes are added that make a setup for one platform fail it would continue for other platforms.