### PR TITLE
Cleanup quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@
 
 [![BuildStatus](https://img.shields.io/circleci/project/github/badges/shields/master?style=for-the-badge)](https://github.com/webui-dev/webui/actions?query=branch%3Amain) [![Issues](https://img.shields.io/github/issues/webui-dev/webui.svg?branch=master&style=for-the-badge&url=https://google.com)](https://github.com/webui-dev/webui/issues) [![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://google.com)](https://webui.me/)
 
-</div>
-
-> Use any web browser as GUI, with your preferred language in the backend and HTML5 in the frontend, all in a lightweight portable lib.
+> WebUI is not a web-server solution or a framework, but it allows you to use any web browser as a GUI, with your preferred language in the backend and HTML5 in the frontend. All in a lightweight portable lib.
 
 ![Screenshot](https://github.com/webui-dev/webui/assets/34311583/57992ef1-4f7f-4d60-8045-7b07df4088c6)
 
-> :warning: **Notice**:
-> 
-> * WebUI it's not a web-server solution or a framework, but it's an lightweight portable lib to use any installed web browser as a user interface.
-> 
-> * We are currently writing documentation.
+</div>
 
 ## Contents
 
@@ -89,6 +83,9 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
 | Runtime Dependencies on macOS | *Cocoa, WebKit* | *QtCore, QtGui, QtWidgets* | ***A Web Browser*** |
 
 ## Documentation
+
+> **Note**
+> We are currently writing documentation.
 
  - [Online Documentation - C](https://webui.me/docs/#/c_api)
  - [Online Documentation - C++](https://webui.me/docs/#/cpp_api)

--- a/README.md
+++ b/README.md
@@ -125,12 +125,13 @@ Think of WebUI like a WebView controller, but instead of embedding the WebView c
 
 | Language | Status | Link |
 | ------ | ------ | ------ |
-| Python | ✔️ | [Python-WebUI](https://github.com/webui-dev/python-webui) |
-| TypeScript / JavaScript | ✔️ | [Deno-WebUI](https://github.com/webui-dev/deno-webui) |
 | Go | ✔️ | [Go-WebUI](https://github.com/webui-dev/go-webui) |
-| Rust | *not complete* | [Rust-WebUI](https://github.com/webui-dev/rust-webui) |
-| V | ✔️ | [V-WebUI](https://github.com/webui-dev/v-webui) |
 | Nim | ✔️ | [Nim-WebUI](https://github.com/webui-dev/nim-webui) |
+| Pascal | ✔️ | [Pascal-WebUI](https://github.com/webui-dev/pascal-webui) |
+| Python | ✔️ | [Python-WebUI](https://github.com/webui-dev/python-webui) |
+| Rust | *not complete* | [Rust-WebUI](https://github.com/webui-dev/rust-webui) |
+| TypeScript / JavaScript | ✔️ | [Deno-WebUI](https://github.com/webui-dev/deno-webui) |
+| V | ✔️ | [V-WebUI](https://github.com/webui-dev/v-webui) |
 | Zig | *not complete* | [Zig-WebUI](https://github.com/webui-dev/zig-webui) |
 
 ## Supported Web Browsers


### PR DESCRIPTION
This suggestion is an attempt to make the readme even cleaner for a polished first impression.

- The block quotes on top of the readme are currently repetitive. So the first point is merged into a single initial statement.
- We are currently writing documentation is moved into the documentation section as GitHub Note highlight.

To save you a few sec navigating to the rendered preview:
current: https://github.com/webui-dev/webui
suggestion: https://github.com/ttytm/webui/tree/docs/update-note

Let me know what you think.