### PR TITLE
Fix `mkdir dist` in build step on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build
         run: |
-          mkdir dist
           if ('${{ matrix.compiler }}' -eq 'MSVC') {
             nmake -f Makefile.nmake
           } else {

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean: --clean-$(PLATFORM)
 --setup:
 # Create build directory
 ifeq ($(PLATFORM),windows)
-	@-$(shell if not exist $(BUILD_DIR) mkdir -p "$(BUILD_DIR)" >nul 2>&1)
+	@mkdir $(BUILD_DIR) >nul 2>&1 ||:
 else
 	@mkdir -p $(BUILD_DIR)
 endif


### PR DESCRIPTION
I encounter the same issue with the dist dir creation in the Makefile when using the library in the V wrapper CI. That the current command to conditionally create a directory on Windows is not working reliable, looks like a version related issue.

The current command `@-$(shell if not exist $(BUILD_DIR) mkdir -p "$(BUILD_DIR)" >nul 2>&1)`
wanted to omit the ignored error message `mingw32-make: [Makefile:77: --setup] Error 1 (ignored)` if the dist directory already existed. With the newly used command this is also possible and it has better compatibility.

 

