### PR TITLE
Fix file deletion in Windows GCC CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR  := $(dir $(MAKEFILE_PATH))
-BUILD_DIR  := "$(MAKEFILE_DIR)/dist"
+BUILD_DIR  := $(MAKEFILE_DIR)/dist
 
 # Args
 # Allow to add arch-target for macOS CI cross compilation
@@ -112,7 +112,7 @@ ifeq ($(PLATFORM),windows)
 	@cd "$(BUILD_DIR)" \
 	&& powershell -command "Remove-Item -Path *.o -Force -ErrorAction SilentlyContinue"
 else
-	@- rm -f "$(BUILD_DIR)/*.o"
+	@- rm -f $(BUILD_DIR)/*.o
 endif
 	@echo "Done."
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,8 @@ endif
 	&& $(COMPILER) -shared -o $(LIB_DYN_OUT) webui.o civetweb.o -g $(LWS2_OPT)
 ifeq ($(PLATFORM),windows)
 	@strip --strip-unneeded "$(BUILD_DIR)/$(LIB_DYN_OUT)"
-	@-cd "$(BUILD_DIR)" && del *.o >nul 2>&1
+	@cd "$(BUILD_DIR)" \
+	&& powershell -command "Remove-Item -Path *.o -Force -ErrorAction SilentlyContinue"
 else
 	@- rm -f "$(BUILD_DIR)/*.o"
 endif
@@ -132,7 +133,8 @@ endif
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@strip --strip-unneeded $(BUILD_DIR)/$(LIB_DYN_OUT)
-	@-cd "$(BUILD_DIR)" && del *.o >nul 2>&1
+	@cd "$(BUILD_DIR)" \
+	&& powershell -command "Remove-Item -Path *.o -Force -ErrorAction SilentlyContinue"
 else
 	@- rm -f $(BUILD_DIR)/*.o
 endif
@@ -148,7 +150,9 @@ endif
 	&& $(COMPILER) $(WEBUI_BUILD_FLAGS) -g -w -DWEBUI_LOG \
 	&& $(LLVM_OPT)ar rc $(LIB_STATIC_OUT) webui.o civetweb.o
 ifeq ($(PLATFORM),windows)
-	@-cd "$(BUILD_DIR)" && del *.o >nul 2>&1
+# Specify `powershell` to call the command to prevent an issue with switching to bash in CI
+	@cd "$(BUILD_DIR)" \
+	&& powershell -command "Remove-Item -Path *.o -Force -ErrorAction SilentlyContinue"
 else
 	@- rm -f $(BUILD_DIR)/*.o
 endif
@@ -163,7 +167,8 @@ endif
 	&& $(LLVM_OPT)ar rc $(LIB_STATIC_OUT) webui.o civetweb.o
 #	Clean
 ifeq ($(PLATFORM),windows)
-	@-cd "$(BUILD_DIR)" && del *.o >nul 2>&1
+	@cd "$(BUILD_DIR)" \
+	&& powershell -command "Remove-Item -Path *.o -Force -ErrorAction SilentlyContinue"
 else
 	@- rm -f $(BUILD_DIR)/*.o
 endif


### PR DESCRIPTION
Fixes the file cleanup for Windows GCC CI builds and remaining file residues in the archives.

The shell switches to bash, despite calling the make command from the default powershell. When we unignore all errors we then get `/usr/bin/bash: line 1: del: command not found`.

Includes a mini revert of a mistake in the last commit. The path should not be enquoted on declaration as we still add more segments to it in other places. Sorry about that.