### PR TITLE
Prevent bridge build permission error

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Bundle WebUI Bridge
         run: |
           npm i -g esbuild
+          chmod +x bridge/build.sh
           bridge/build.sh
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Bundle WebUI Bridge
         run: |
           npm i -g esbuild
+          chmod +x bridge/build.sh
           bridge/build.sh
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}-bridge
           fail-on-cache-miss: true
       - uses: microsoft/setup-msbuild@v1.1
-      - if: ${{ matrix.compiler == 'MSVC' }}
+      - if: matrix.compiler == 'MSVC'
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build
         run: |


### PR DESCRIPTION
Testing the release workflow. I've run into the possibility to encounter permission errors when running the build script for the client. This change makes sure permissions are set.
