### PR TITLE
Include debug builds in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
 
-  build-release:
+  build:
     needs: setup
     runs-on: ubuntu-latest
     permissions:
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         compiler: [GCC, Clang]
+        kind: [release, debug]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -40,11 +41,14 @@ jobs:
             sudo ln -s llvm-ranlib-13 /usr/bin/llvm-ranlib
           fi
           compiler=${{ matrix.compiler }}
-          make COMPILER=${compiler,,}
+          make COMPILER=${compiler,,} ${{ matrix.kind }}
       - name: Prepare Artifact
         run: |
           cp -r include dist
-          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}-x64
+          if [ "${{ matrix.kind }}" == "debug" ]; then
+            kind="-${{ matrix.kind }}"
+          fi
+          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}$kind-x64
           # Convert to lowercase (`,,` ^= lowercase shell param)
           artifact=${artifact,,}
           # Add the ARTIFACT name as GitHub environment variable.
@@ -57,7 +61,7 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
       - name: Release Artifact
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && matrix.kind == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
 
-  build-release:
+  build:
     needs: setup
     runs-on: macos-latest
     permissions:
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         compiler: [Clang]
+        kind: [release, debug]
         arch: [x64, arm64]
     steps:
       - uses: actions/checkout@v3
@@ -36,15 +37,18 @@ jobs:
       - name: Build
         run: |
           if [ "${{ matrix.arch }}" == "arm64" ]; then
-            make ARCH_TARGET="-target arm64-apple-darwin"
+            make ARCH_TARGET="-target arm64-apple-darwin" ${{ matrix.kind }}
           else
-            make
+            make ${{ matrix.kind }}
           fi
       - name: Prepare Artifacts
         run: |
           cp -r include dist
+          if [ "${{ matrix.kind }}" == "debug" ]; then
+            kind="-${{ matrix.kind }}"
+          fi
           # Add the ARTIFACT name(lowercased) as GitHub environment variable.
-          artifact=$(echo ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
+          artifact=$(echo ${{ runner.os }}-${{ matrix.compiler }}$kind-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
           tar -czvf $artifact.tar.gz $artifact
@@ -54,7 +58,7 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
       - name: Release Artifact
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && matrix.kind == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
             kind="-${{ matrix.kind }}"
           fi
           # Add the ARTIFACT name(lowercased) as GitHub environment variable.
-          artifact=$(echo ${{ runner.os }}-${{ matrix.compiler }}$kind-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
+          artifact=webui-$(echo ${{ runner.os }}-${{ matrix.compiler }}$kind-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
           tar -czvf $artifact.tar.gz $artifact

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
 
-  build-release:
+  build:
     needs: setup
     runs-on: windows-latest
     permissions:
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         compiler: [GCC, MSVC]
+        kind: [release, debug]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -36,15 +37,18 @@ jobs:
       - name: Build
         run: |
           if ('${{ matrix.compiler }}' -eq 'MSVC') {
-            nmake -f ./Makefile.nmake
+            nmake -f ./Makefile.nmake ${{ matrix.kind }}
           } else {
-            mingw32-make
+            mingw32-make ${{ matrix.kind }}
           }
       - name: Prepare Artifact
         shell: bash
         run: |
           cp -r include dist
-          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}-x64
+          if [ "${{ matrix.kind }}" == "debug" ]; then
+            kind="-${{ matrix.kind }}"
+          fi
+          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}$kind-x64
           # Convert to lowercase (`,,` ^= lowercase shell param)
           artifact=${artifact,,}
           # Add the ARTIFACT name as GitHub environment variable.
@@ -57,7 +61,7 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
       - name: Release Artifact
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && matrix.kind == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}.zip


### PR DESCRIPTION
Adds building of the debug version to the CI workflow.

That way users could always download pre-built static for the latest commit from the github actions artifacts. (Related https://github.com/webui-dev/pascal-webui/issues/3#issuecomment-1699829791)

Also, if I recall it right, after moving to the single Makefile approach, you had to fix an issue with the debug build that might have been covered when `make debug` would be part of CI.

E.g.: https://github.com/ttytm/webui/actions/runs/6040804140

When creating a tag release, still only the release version would be uploaded to github releases.
