### PR TITLE
Improve directory independency of Makefile Dir variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 
 # == 1. VARIABLES =============================================================
 
-MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-MAKEFILE_DIR  := $(dir $(MAKEFILE_PATH))
+MAKEFILE_DIR  := $(shell git rev-parse --show-toplevel)
 BUILD_DIR  := $(MAKEFILE_DIR)/dist
 
 # Args

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -4,17 +4,16 @@
 # == 1. VARIABLES =============================================================
 
 # Paths
-MAKEFILE_DIR  = ./
-BUILD_DIR = $(MAKEFILE_DIR)/dist/
+BUILD_DIR = $(MAKEDIR)/dist
 
 # Build Flags
-CIVETWEB_BUILD_FLAGS = /Fo$(BUILD_DIR)civetweb.obj /c /EHsc "$(MAKEFILE_DIR)/src/civetweb/civetweb.c" /I "$(MAKEFILE_DIR)/src/civetweb/"
+CIVETWEB_BUILD_FLAGS = /Fo$(BUILD_DIR)/civetweb.obj /c /EHsc $(MAKEDIR)/src/civetweb/civetweb.c /I $(MAKEDIR)/src/civetweb/
 CIVETWEB_DEFINE_FLAGS = -DNDEBUG -DNO_CACHING -DNO_CGI -DNO_SSL -DUSE_WEBSOCKET
-WEBUI_BUILD_FLAGS = /Fo$(BUILD_DIR)webui.obj /c /EHsc "$(MAKEFILE_DIR)/src/webui.c" /I "$(MAKEFILE_DIR)include"
+WEBUI_BUILD_FLAGS = /Fo$(BUILD_DIR)/webui.obj /c /EHsc $(MAKEDIR)/src/webui.c /I $(MAKEDIR)/include
 
 # Output Commands
-LIB_STATIC_OUT = /OUT:$(BUILD_DIR)webui-2-static.lib $(BUILD_DIR)webui.obj $(BUILD_DIR)civetweb.obj
-LIB_DYN_OUT = /DLL /OUT:$(BUILD_DIR)webui-2.dll $(BUILD_DIR)webui.obj $(BUILD_DIR)civetweb.obj user32.lib Advapi32.lib
+LIB_STATIC_OUT = /OUT:$(BUILD_DIR)/webui-2-static.lib $(BUILD_DIR)/webui.obj $(BUILD_DIR)/civetweb.obj
+LIB_DYN_OUT = /DLL /OUT:$(BUILD_DIR)/webui-2.dll $(BUILD_DIR)/webui.obj $(BUILD_DIR)/civetweb.obj user32.lib Advapi32.lib
 
 # == 2.TARGETS ================================================================
 


### PR DESCRIPTION
This PR:

- makes use of the `git rev-parse --show-topleve` shell command (same as it's done in brdige/build.sh) in our regular `Makefile` to get the Makefile directory.

- utilizes `MAKEDIR` which comes with nmake in `Makefile.nmake` it to get the Makefile dir instead of fixing it to `./`. 
  also makes `/` usage in paths consistent.