### PR TITLE
Remove remaining `@cd "$(_LIB)" && $(MAKE)` residues in examples

### DIFF
--- a/examples/C++/call_cpp_from_js/Windows/MSVC/Makefile
+++ b/examples/C++/call_cpp_from_js/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C++/call_cpp_from_js/macOS/Clang/Makefile
+++ b/examples/C++/call_cpp_from_js/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
 	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
 	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C++ Example (Static Release)..."
 	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
 	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."

--- a/examples/C++/call_js_from_cpp/Windows/MSVC/Makefile
+++ b/examples/C++/call_js_from_cpp/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C++/call_js_from_cpp/macOS/Clang/Makefile
+++ b/examples/C++/call_js_from_cpp/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
 	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
 	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C++ Example (Static Release)..."
 	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
 	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."

--- a/examples/C++/minimal/Windows/MSVC/Makefile
+++ b/examples/C++/minimal/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C++/minimal/macOS/Clang/Makefile
+++ b/examples/C++/minimal/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
 	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
 	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C++ Example (Static Release)..."
 	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
 	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."

--- a/examples/C++/serve_a_folder/Windows/MSVC/Makefile
+++ b/examples/C++/serve_a_folder/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi /EHsc /std:c++17 "$(_SOURCE)/main.cpp" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C++ Example (Release Static)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C++/serve_a_folder/macOS/Clang/Makefile
+++ b/examples/C++/serve_a_folder/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C++ Example (Static Debug)..."
 	@clang -std=c++17 -g -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C++ Example (Dynamic Debug)..."
 	@clang -std=c++17 -g -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C++ Example (Static Release)..."
 	@clang -std=c++17 -lstdc++ -Os -m64 -o main "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C++ Example (Dynamic Release)..."
 	@clang -std=c++17 -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.cpp" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."

--- a/examples/C/call_js_from_c/Windows/MSVC/Makefile
+++ b/examples/C/call_js_from_c/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C/call_js_from_c/macOS/Clang/Makefile
+++ b/examples/C/call_js_from_c/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
 	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
 	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C99 Example (Static Release)..."
 	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
 	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."

--- a/examples/C/minimal/Windows/MSVC/Makefile
+++ b/examples/C/minimal/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C/minimal/macOS/Clang/Makefile
+++ b/examples/C/minimal/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
 	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
 	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C99 Example (Static Release)..."
 	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
 	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."

--- a/examples/C/serve_a_folder/Windows/MSVC/Makefile
+++ b/examples/C/serve_a_folder/Windows/MSVC/Makefile
@@ -10,8 +10,6 @@ _SOURCE=../../
 all: release
 
 debug:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE) debug
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
 	@rc win.rc 1>NUL 2>&1
@@ -22,8 +20,6 @@ debug:
 	@cl /Zi "$(_SOURCE)/main.c" /I "$(_INCLUDE)" /link /LIBPATH:"$(_LIB)" /MACHINE:X64 /SUBSYSTEM:CONSOLE win.res webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 
 release:
-#	Build Lib
-	@cd "$(_LIB)" && $(MAKE)
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@rc win.rc 1>NUL 2>&1

--- a/examples/C/serve_a_folder/macOS/Clang/Makefile
+++ b/examples/C/serve_a_folder/macOS/Clang/Makefile
@@ -9,29 +9,25 @@ SOURCE=../..
 all: release
 
 debug:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE) debug
-    # Static with Debug info
+# Static with Debug info
 	@echo "Build C99 Example (Static Debug)..."
 	@clang -g -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic with Debug info
+# Dynamic with Debug info
 	@echo "Build C99 Example (Dynamic Debug)..."
 	@clang -g -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."
 
 release:
-    # Build Lib
-	@cd "$(LIB)" && $(MAKE)
-    # Static Release
+# Static Release
 	@echo "Build C99 Example (Static Release)..."
 	@clang -lstdc++ -Os -m64 -o main "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" -lwebui-2-static -lpthread -lm
-    # Dynamic Release
+# Dynamic Release
 	@echo "Build C99 Example (Dynamic Release)..."
 	@clang -lstdc++ -m64 -o main-dyn "$(SOURCE)/main.c" -I "$(INCLUDE)" -L "$(LIB)" "$(LIB)/webui-2.dyn" -lpthread -lm
-    # Clean
+# Clean
 	@- rm -f *.o
 	@- rm -rf *.dSYM
 	@echo "Done."


### PR DESCRIPTION
\+ make uniform usage of comments in macos Makefiles - the current version with the leading spaces prints the comments.