### PR TITLE
Update images with wide widths to fill content

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This [text editor example](https://github.com/webui-dev/webui/tree/main/examples
 
 <div align="center">
 
-![CPPCon](https://github.com/webui-dev/webui/assets/34311583/cf796ead-66d3-4298-ac80-b551c25f3e41)
+![CPPCon](https://github.com/webui-dev/webui/assets/34311583/4e830caa-4ca0-44ff-825f-7cd6d94083c8)
 
 </div>
 
@@ -73,7 +73,7 @@ Today's web browsers have everything a modern UI needs. Web browsers are very so
 
 <div align="center">
 
-![Diagram](https://github.com/webui-dev/webui/assets/34311583/ef56944a-d92c-44cb-935a-affc8a442eb4)
+![Diagram](https://github.com/ttytm/webui/assets/34311583/dbde3573-3161-421e-925c-392a39f45ab3)
 
 </div>
 


### PR DESCRIPTION
This includes a minor cosmetic change.

It updates the "wide" images in the readme to re-created versions. The main goal was to make all wide images fill a readmes max content (1012px is max at GH afaik). 

For the other changes, I hoped the updated cppcon snapshot is in initially a bit simpler and more interesting and that the Diagram image transmits the point of how easy it is to create an application with full OS API access (it's obvious when thinking about it, now it's in the image as well). The Diagram also won't use a shadow anymore to keep things uniform.

Quick link to rendered preview: https://github.com/ttytm/webui/tree/readme/update-images

The current state is also good, and those are things where preferences might differ, so please tell if the changes are a +.