### PR TITLE
Improve debug build target usage

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         compiler: [GCC, Clang]
-        kind: [release, debug]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -34,34 +33,38 @@ jobs:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
           fail-on-cache-miss: true
-      - name: Build
+      - name: Link Libraries
+        if: matrix.compiler == 'clang'
         run: |
-          if [ "${{ matrix.compiler }}" == "Clang" ]; then
-            sudo ln -s llvm-ar-13 /usr/bin/llvm-ar
-            sudo ln -s llvm-ranlib-13 /usr/bin/llvm-ranlib
-          fi
+          sudo ln -s llvm-ar-13 /usr/bin/llvm-ar
+          sudo ln -s llvm-ranlib-13 /usr/bin/llvm-ranlib
+      - name: Build Debug Target
+        run: |
           compiler=${{ matrix.compiler }}
-          make COMPILER=${compiler,,} ${{ matrix.kind }}
+          make COMPILER=${compiler,,} debug
+      - name: Build Release Target
+        run: |
+          compiler=${{ matrix.compiler }}
+          make COMPILER=${compiler,,}
       - name: Prepare Artifact
         run: |
           cp -r include dist
-          if [ "${{ matrix.kind }}" == "debug" ]; then
-            kind="-${{ matrix.kind }}"
-          fi
-          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}$kind-x64
+          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}-x64
           # Convert to lowercase (`,,` ^= lowercase shell param)
           artifact=${artifact,,}
           # Add the ARTIFACT name as GitHub environment variable.
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
-          tar -czvf $artifact.tar.gz $artifact
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
-      - name: Release Artifact
-        if: github.ref_type == 'tag' && matrix.kind == 'release'
+      - name: Prepare Release Archive
+        if: github.ref_type == 'tag'
+        run: tar -czvf $artifact.tar.gz ${{ env.ARTIFACT }}
+      - name: Release
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         compiler: [Clang]
-        kind: [release, debug]
         arch: [x64, arm64]
     steps:
       - uses: actions/checkout@v3
@@ -34,31 +33,37 @@ jobs:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
           fail-on-cache-miss: true
-      - name: Build
+      - name: Build Debug Target
         run: |
           if [ "${{ matrix.arch }}" == "arm64" ]; then
-            make ARCH_TARGET="-target arm64-apple-darwin" ${{ matrix.kind }}
+            make ARCH_TARGET="-target arm64-apple-darwin" debug
           else
-            make ${{ matrix.kind }}
+            make debug
+          fi
+      - name: Build Release Target
+        run: |
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
+            make ARCH_TARGET="-target arm64-apple-darwin"
+          else
+            make
           fi
       - name: Prepare Artifacts
         run: |
           cp -r include dist
-          if [ "${{ matrix.kind }}" == "debug" ]; then
-            kind="-${{ matrix.kind }}"
-          fi
           # Add the ARTIFACT name(lowercased) as GitHub environment variable.
-          artifact=webui-$(echo ${{ runner.os }}-${{ matrix.compiler }}$kind-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
+          artifact=webui-$(echo ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
-          tar -czvf $artifact.tar.gz $artifact
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
-      - name: Release Artifact
-        if: github.ref_type == 'tag' && matrix.kind == 'release'
+      - name: Prepare Release Archive
+        if: github.ref_type == 'tag'
+        run: tar -czvf $artifact.tar.gz ${{ env.ARTIFACT }}
+      - name: Release
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}.tar.gz

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         compiler: [GCC, MSVC]
-        kind: [release, debug]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -34,34 +33,40 @@ jobs:
       - uses: microsoft/setup-msbuild@v1.1
       - if: matrix.compiler == 'MSVC'
         uses: ilammy/msvc-dev-cmd@v1
-      - name: Build
+      - name: Build Debug Target
         run: |
           if ('${{ matrix.compiler }}' -eq 'MSVC') {
-            nmake -f ./Makefile.nmake ${{ matrix.kind }}
+            nmake -f ./Makefile.nmake debug
           } else {
-            mingw32-make ${{ matrix.kind }}
+            mingw32-make debug
+          }
+      - name: Build Release Target
+        run: |
+          if ('${{ matrix.compiler }}' -eq 'MSVC') {
+            nmake -f ./Makefile.nmake
+          } else {
+            mingw32-make
           }
       - name: Prepare Artifact
         shell: bash
         run: |
           cp -r include dist
-          if [ "${{ matrix.kind }}" == "debug" ]; then
-            kind="-${{ matrix.kind }}"
-          fi
-          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}$kind-x64
+          artifact=webui-${{ runner.os }}-${{ matrix.compiler }}-x64
           # Convert to lowercase (`,,` ^= lowercase shell param)
           artifact=${artifact,,}
           # Add the ARTIFACT name as GitHub environment variable.
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
-          7z a -tzip $artifact.zip $artifact
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
+      - name: Prepare Release Archive
+        if: github.ref_type == 'tag'
+        run: 7z a -tzip $artifact.zip ${{ env.ARTIFACT }}
       - name: Release Artifact
-        if: github.ref_type == 'tag' && matrix.kind == 'release'
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}.zip

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -3,25 +3,23 @@
 
 # == 1. VARIABLES =============================================================
 
-# Paths
-BUILD_DIR = $(MAKEDIR)/dist
-
 # Build Flags
-CIVETWEB_BUILD_FLAGS = /Fo$(BUILD_DIR)/civetweb.obj /c /EHsc $(MAKEDIR)/src/civetweb/civetweb.c /I$(MAKEDIR)/src/civetweb/
+CIVETWEB_BUILD_FLAGS = /Fo"civetweb.obj" /c /EHsc "$(MAKEDIR)/src/civetweb/civetweb.c" /I"$(MAKEDIR)/src/civetweb/"
 CIVETWEB_DEFINE_FLAGS = -DNDEBUG -DNO_CACHING -DNO_CGI -DNO_SSL -DUSE_WEBSOCKET
-WEBUI_BUILD_FLAGS = /Fo$(BUILD_DIR)/webui.obj /c /EHsc $(MAKEDIR)/src/webui.c /I$(MAKEDIR)/include
+WEBUI_BUILD_FLAGS = /Fo"webui.obj" /c /EHsc "$(MAKEDIR)/src/webui.c" /I"$(MAKEDIR)/include"
 
 # Output Commands
-LIB_STATIC_OUT = /OUT:$(BUILD_DIR)/webui-2-static.lib $(BUILD_DIR)/webui.obj $(BUILD_DIR)/civetweb.obj
-LIB_DYN_OUT = /DLL /OUT:$(BUILD_DIR)/webui-2.dll $(BUILD_DIR)/webui.obj $(BUILD_DIR)/civetweb.obj user32.lib Advapi32.lib
+LIB_STATIC_OUT = /OUT:"webui-2-static.lib" "webui.obj" "civetweb.obj"
+LIB_DYN_OUT = /DLL /OUT:"webui-2.dll" "webui.obj" "civetweb.obj" user32.lib Advapi32.lib
 
 # == 2.TARGETS ================================================================
 
 all: release
 
 debug:
-	@- mkdir dist >nul 2>&1
+	@- mkdir dist\debug >nul 2>&1
 #	Static with Debug info
+	@- cd $(MAKEDIR)/dist/debug
 	@echo Build WebUI Library (MSVC Debug Static)...
 	@cl /Zl /Zi $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
 	@cl /Zl /Zi $(WEBUI_BUILD_FLAGS) /DWEBUI_LOG
@@ -31,12 +29,20 @@ debug:
 	@cl /Zi $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
 	@cl /Zi $(WEBUI_BUILD_FLAGS) /DWEBUI_LOG
 	@link $(LIB_DYN_OUT)
+#	Move into `debug/` dir
+	@- move webui-2-static.lib "debug\"
+	@- move webui-2.dll "debug\"
 #	Clean
 	@- del *.pdb >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@- del *.exp >nul 2>&1
 	@echo Done.
 
 release:
 	@- mkdir dist >nul 2>&1
+	@- cd $(MAKEDIR)/dist
 #	Static Release
 	@echo Build WebUI Library (MSVC Release Static)...
 	@cl /Zl $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
@@ -49,7 +55,6 @@ release:
 	@link $(LIB_DYN_OUT)
 #	Clean
 	@- del *.pdb >nul 2>&1
-	@- cd $(BUILD_DIR)
 	@- del *.obj >nul 2>&1
 	@- del *.ilk >nul 2>&1
 	@- del *.pdb >nul 2>&1
@@ -57,8 +62,8 @@ release:
 	@- echo Done.
 
 clean:
-	@- del *.pdb >nul 2>&1
 	@- cd $(BUILD_DIR)
+	@- del *.pdb >nul 2>&1
 	@- del *.obj >nul 2>&1
 	@- del *.ilk >nul 2>&1
 	@- del *.pdb >nul 2>&1

--- a/examples/C++/call_cpp_from_js/Makefile
+++ b/examples/C++/call_cpp_from_js/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -std=c++17 -lstdc++ -m64 main.cpp -I"$(INCLUDE_DIR)" -L"$(LIB_
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,36 +52,41 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
-	@echo "Build C99 Example (Static Debug)..."
+	@echo "Build C99 Example ($(CXX) debug static)..."
 	@$(CXX) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 #	Dynamic with Debug info
-	@echo "Build C99 Example (Dynamic Debug)..."
+	@echo "Build C99 Example ($(CXX) debug dynamic)..."
 	@$(CXX) -g $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
-	@echo "Build C99 Example (Static Release)..."
+	@echo "Build C99 Example ($(CXX) release static)..."
 	@$(CXX) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(STATIC_OUT)
 #	Dynamic Release
-	@echo "Build C99 Example (Dynamic Release)..."
+	@echo "Build C99 Example ($(CXX) release dynamic)..."
 	@$(CXX) $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CXX),g++ clang),$(CXX))
 	$(error Invalid compiler specified: `$(CXX)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C++/call_cpp_from_js/Makefile.nmake
+++ b/examples/C++/call_cpp_from_js/Makefile.nmake
@@ -10,26 +10,40 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C++ Example (Release Static)...
-	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C++/call_js_from_cpp/Makefile
+++ b/examples/C++/call_js_from_cpp/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -std=c++17 -lstdc++ -m64 main.cpp -I"$(INCLUDE_DIR)" -L"$(LIB_
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,36 +52,41 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
-	@echo "Build C99 Example (Static Debug)..."
+	@echo "Build C99 Example ($(CXX) debug static)..."
 	@$(CXX) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 #	Dynamic with Debug info
-	@echo "Build C99 Example (Dynamic Debug)..."
+	@echo "Build C99 Example ($(CXX) debug dynamic)..."
 	@$(CXX) -g $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
-	@echo "Build C99 Example (Static Release)..."
+	@echo "Build C99 Example ($(CXX) release static)..."
 	@$(CXX) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(STATIC_OUT)
 #	Dynamic Release
-	@echo "Build C99 Example (Dynamic Release)..."
+	@echo "Build C99 Example ($(CXX) release dynamic)..."
 	@$(CXX) $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CXX),g++ clang),$(CXX))
 	$(error Invalid compiler specified: `$(CXX)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C++/call_js_from_cpp/Makefile.nmake
+++ b/examples/C++/call_js_from_cpp/Makefile.nmake
@@ -10,26 +10,40 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C++ Example (Release Static)...
-	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C++/minimal/Makefile
+++ b/examples/C++/minimal/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -std=c++17 -lstdc++ -m64 main.cpp -I"$(INCLUDE_DIR)" -L"$(LIB_
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,36 +52,41 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
-	@echo "Build C99 Example (Static Debug)..."
+	@echo "Build C99 Example ($(CXX) debug static)..."
 	@$(CXX) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 #	Dynamic with Debug info
-	@echo "Build C99 Example (Dynamic Debug)..."
+	@echo "Build C99 Example ($(CXX) debug dynamic)..."
 	@$(CXX) -g $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
-	@echo "Build C99 Example (Static Release)..."
+	@echo "Build C99 Example ($(CXX) release static)..."
 	@$(CXX) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(STATIC_OUT)
 #	Dynamic Release
-	@echo "Build C99 Example (Dynamic Release)..."
+	@echo "Build C99 Example ($(CXX) release dynamic)..."
 	@$(CXX) $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CXX),g++ clang),$(CXX))
 	$(error Invalid compiler specified: `$(CXX)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C++/minimal/Makefile.nmake
+++ b/examples/C++/minimal/Makefile.nmake
@@ -10,26 +10,40 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C++ Example (Release Static)...
-	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C++/serve_a_folder/Makefile
+++ b/examples/C++/serve_a_folder/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -std=c++17 -lstdc++ -m64 main.cpp -I"$(INCLUDE_DIR)" -L"$(LIB_
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,36 +52,41 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
-	@echo "Build C99 Example (Static Debug)..."
+	@echo "Build C99 Example ($(CXX) debug static)..."
 	@$(CXX) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 #	Dynamic with Debug info
-	@echo "Build C99 Example (Dynamic Debug)..."
+	@echo "Build C99 Example ($(CXX) debug dynamic)..."
 	@$(CXX) -g $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
-	@echo "Build C99 Example (Static Release)..."
+	@echo "Build C99 Example ($(CXX) release static)..."
 	@$(CXX) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(STATIC_OUT)
 #	Dynamic Release
-	@echo "Build C99 Example (Dynamic Release)..."
+	@echo "Build C99 Example ($(CXX) release dynamic)..."
 	@$(CXX) $(DYN_BUILD_FLAGS) $(LWS2_OPT) -o $(DYN_OUT)
 	@$(LLVM_OPT)strip $(STRIP_OPT) $(DYN_OUT)
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CXX),g++ clang),$(CXX))
 	$(error Invalid compiler specified: `$(CXX)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C++/serve_a_folder/Makefile.nmake
+++ b/examples/C++/serve_a_folder/Makefile.nmake
@@ -10,26 +10,40 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C++ Example (Debug Static)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C++ Example (Debug Dynamic)...
-	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C++ Example (Release Static)...
-	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS win.res webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic Release
 	@echo Build C++ Example (Release Dynamic)...
 	@cl /EHsc /std:c++17 main.cpp /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C/call_c_from_js/Makefile
+++ b/examples/C/call_c_from_js/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -m64 main.c -I"$(INCLUDE_DIR)" -L"$(LIB_DIR)"
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,7 +52,11 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
 	@echo "Build C99 Example ($(CC) debug static)..."
 	@$(CC) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -62,14 +66,16 @@ debug: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
 	@echo "Build C99 Example ($(CC) release static)..."
 	@$(CC) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -81,7 +87,6 @@ release: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CC),gcc clang),$(CC))
 	$(error Invalid compiler specified: `$(CC)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C/call_c_from_js/Makefile.nmake
+++ b/examples/C/call_c_from_js/Makefile.nmake
@@ -10,15 +10,28 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
@@ -26,10 +39,11 @@ release: --setup
 	@echo Build C99 Example (Dynamic Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C/call_js_from_c/Makefile
+++ b/examples/C/call_js_from_c/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -m64 main.c -I"$(INCLUDE_DIR)" -L"$(LIB_DIR)"
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,7 +52,11 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
 	@echo "Build C99 Example ($(CC) debug static)..."
 	@$(CC) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -62,14 +66,16 @@ debug: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
 	@echo "Build C99 Example ($(CC) release static)..."
 	@$(CC) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -81,7 +87,6 @@ release: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CC),gcc clang),$(CC))
 	$(error Invalid compiler specified: `$(CC)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C/call_js_from_c/Makefile.nmake
+++ b/examples/C/call_js_from_c/Makefile.nmake
@@ -10,15 +10,28 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
@@ -26,10 +39,11 @@ release: --setup
 	@echo Build C99 Example (Dynamic Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C/minimal/Makefile
+++ b/examples/C/minimal/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -m64 main.c -I"$(INCLUDE_DIR)" -L"$(LIB_DIR)"
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,7 +52,11 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
 	@echo "Build C99 Example ($(CC) debug static)..."
 	@$(CC) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -62,14 +66,16 @@ debug: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
 	@echo "Build C99 Example ($(CC) release static)..."
 	@$(CC) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -81,7 +87,6 @@ release: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CC),gcc clang),$(CC))
 	$(error Invalid compiler specified: `$(CC)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C/minimal/Makefile.nmake
+++ b/examples/C/minimal/Makefile.nmake
@@ -10,15 +10,28 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
@@ -26,10 +39,11 @@ release: --setup
 	@echo Build C99 Example (Dynamic Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF

--- a/examples/C/serve_a_folder/Makefile
+++ b/examples/C/serve_a_folder/Makefile
@@ -20,7 +20,7 @@ DYN_BUILD_FLAGS = -m64 main.c -I"$(INCLUDE_DIR)" -L"$(LIB_DIR)"
 ifeq ($(OS),Windows_NT)
 	# Windows
 	PLATFORM := windows
-	SHELL=CMD
+	SHELL := CMD
 	STATIC_BUILD_FLAGS += -lwebui-2-static -lws2_32 -Wall -Wl,-subsystem=console -luser32 -static
 	DYN_BUILD_FLAGS += "$(LIB_DIR)/webui-2.dll" -lws2_32 -Wall -Wl,-subsystem=console -luser32
 	STATIC_OUT := main.exe
@@ -52,7 +52,11 @@ endif
 
 all: release
 
-debug: --setup
+debug: LIB_DIR := $(LIB_DIR)/debug
+debug: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE) debug
+endif
 #	Static with Debug info
 	@echo "Build C99 Example ($(CC) debug static)..."
 	@$(CC) -g $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -62,14 +66,16 @@ debug: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
 endif
 	@echo "Done."
 
-release: --setup
+release: --validate-args
+ifeq ($(BUILD_LIB),true)
+	@cd "$(PROJECT_DIR)" && $(MAKE)
+endif
 #	Static Release
 	@echo "Build C99 Example ($(CC) release static)..."
 	@$(CC) -Os $(STATIC_BUILD_FLAGS) $(LWS2_OPT) -o $(STATIC_OUT)
@@ -81,7 +87,6 @@ release: --setup
 #	Clean
 ifeq ($(PLATFORM),windows)
 	@- del *.o >nul 2>&1
-	@- del *.res >nul 2>&1
 else
 	@- rm -f *.o
 	@- rm -rf *.dSYM # macOS
@@ -92,12 +97,9 @@ clean: --clean-$(PLATFORM)
 
 # INTERNAL TARGETS
 
---setup:
+--validate-args:
 ifneq ($(filter $(CC),gcc clang),$(CC))
 	$(error Invalid compiler specified: `$(CC)`)
-endif
-ifeq ($(BUILD_LIB),true)
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE)
 endif
 
 --clean-linux: --clean-unix
@@ -116,4 +118,3 @@ endif
 	- del *.dll >nul 2>&1
 	- del *.a >nul 2>&1
 	- del *.exe >nul 2>&1
-	- del *.res >nul 2>&1

--- a/examples/C/serve_a_folder/Makefile.nmake
+++ b/examples/C/serve_a_folder/Makefile.nmake
@@ -10,15 +10,28 @@ BUILD_LIB =
 
 all: release
 
-debug: --setup
+debug:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake debug
+!ENDIF
 #	Static with Debug info
 	@echo Build C99 Example (Static Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
 #	Dynamic with Debug info
 	@echo Build C99 Example (Dynamic Debug)...
-	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+	@cl /Zi main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)/debug" /MACHINE:X64 /SUBSYSTEM:CONSOLE webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
+#	Clean
+	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
+	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
+	@echo Done.
 
-release: --setup
+release:
+!IF "$(BUILD_LIB)" == "true"
+	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
+!ENDIF
 #	Static Release
 	@echo Build C99 Example (Static Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2-static.lib user32.lib Advapi32.lib /OUT:main.exe 1>NUL 2>&1
@@ -26,10 +39,11 @@ release: --setup
 	@echo Build C99 Example (Dynamic Release)...
 	@cl main.c /I"$(INCLUDE_DIR)" /link /LIBPATH:"$(LIB_DIR)" /MACHINE:X64 /SUBSYSTEM:WINDOWS webui-2.lib user32.lib Advapi32.lib /OUT:main-dyn.exe 1>NUL 2>&1
 #	Clean
-	@- del *.res >nul 2>&1
-	@- del *.obj >nul 2>&1
 	@- del *.exp >nul 2>&1
+	@- del *.ilk >nul 2>&1
 	@- del *.lib >nul 2>&1
+	@- del *.obj >nul 2>&1
+	@- del *.pdb >nul 2>&1
 	@echo Done.
 
 clean:
@@ -39,9 +53,3 @@ clean:
 	- del *.exp >nul 2>&1
 	- del *.exe >nul 2>&1
 	- del *.lib >nul 2>&1
-	- del *.res >nul 2>&1
-
---setup:
-!IF "$(BUILD_LIB)" == "true"
-	@cd "$(LIB_DIR)" && cd .. && $(MAKE) -f Makefile.nmake
-!ENDIF


### PR DESCRIPTION
Using a distinct file for debug builds would simplify some things imho. There are a bunch of cases where it makes sense to have both files side by side.

If you also see value in this, I'd finish it here.