### PR TITLE
Implement nightly releases

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,11 +68,33 @@ jobs:
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
-      - name: Prepare Release Archive
-        if: github.ref_type == 'tag'
-        run: tar -czvf $artifact.tar.gz ${{ env.ARTIFACT }}
-      - name: Release
-        if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v1
+      - name: Prepare Release
+        if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
+        run: |
+          tar -czvf ${{ env.ARTIFACT }}.tar.gz ${{ env.ARTIFACT }}
+          if [ $GITHUB_REF_TYPE == tag ]; then
+            echo "TAG=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          else
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            now=$(date -u +'%Y-%m-%d %H:%M:%S UTC')
+            echo "TAG=nightly" >> $GITHUB_ENV
+            echo "BODY=Generated on <samp>$now</samp> from commit ${{ github.sha }}." >> $GITHUB_ENV
+            echo "TITLE=WebUI Development Build" >> $GITHUB_ENV
+          fi
+      - name: Update Nightly Tag
+        if: env.IS_PRERELEASE
+        uses: richardsimko/update-tag@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ${{ env.ARTIFACT }}.tar.gz
+          tag_name: nightly
+      - name: Release
+        if: github.ref_name == 'main' && (github.ref_type == 'tag' || github.event_name == 'push')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ env.ARTIFACT }}.tar.gz
+          tag: ${{ env.TAG }}
+          body: ${{ env.BODY }}
+          name: ${{ env.TITLE }}
+          prerelease: ${{ env.IS_PRERELEASE }}
+          allowUpdates: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,11 +67,33 @@ jobs:
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
-      - name: Prepare Release Archive
-        if: github.ref_type == 'tag'
-        run: tar -czvf $artifact.tar.gz ${{ env.ARTIFACT }}
-      - name: Release
-        if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v1
+      - name: Prepare Release
+        if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
+        run: |
+          tar -czvf ${{ env.ARTIFACT }}.tar.gz ${{ env.ARTIFACT }}
+          if [ $GITHUB_REF_TYPE == tag ]; then
+            echo "TAG=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          else
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            now=$(date -u +'%Y-%m-%d %H:%M:%S UTC')
+            echo "TAG=nightly" >> $GITHUB_ENV
+            echo "BODY=Generated on <samp>$now</samp> from commit ${{ github.sha }}." >> $GITHUB_ENV
+            echo "TITLE=WebUI Development Build" >> $GITHUB_ENV
+          fi
+      - name: Update Nightly Tag
+        if: env.IS_PRERELEASE
+        uses: richardsimko/update-tag@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ${{ env.ARTIFACT }}.tar.gz
+          tag_name: nightly
+      - name: Release
+        if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ env.ARTIFACT }}.tar.gz
+          tag: ${{ env.TAG }}
+          body: ${{ env.BODY }}
+          name: ${{ env.TITLE }}
+          prerelease: ${{ env.IS_PRERELEASE }}
+          allowUpdates: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,11 +70,34 @@ jobs:
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
-      - name: Prepare Release Archive
-        if: github.ref_type == 'tag'
-        run: 7z a -tzip $artifact.zip ${{ env.ARTIFACT }}
-      - name: Release Artifact
-        if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v1
+      - name: Prepare Release
+        if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
+        shell: bash
+        run: |
+          7z a -tzip ${{ env.ARTIFACT }}.zip ${{ env.ARTIFACT }}
+          if [ $GITHUB_REF_TYPE == tag ]; then
+            echo "TAG=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          else
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            now=$(date -u +'%Y-%m-%d %H:%M:%S UTC')
+            echo "TAG=nightly" >> $GITHUB_ENV
+            echo "BODY=Generated on <samp>$now</samp> from commit ${{ github.sha }}." >> $GITHUB_ENV
+            echo "TITLE=WebUI Development Build" >> $GITHUB_ENV
+          fi
+      - name: Update Nightly Tag
+        if: env.IS_PRERELEASE
+        uses: richardsimko/update-tag@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ${{ env.ARTIFACT }}.zip
+          tag_name: nightly
+      - name: Release
+        if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ env.ARTIFACT }}.zip
+          tag: ${{ env.TAG }}
+          body: ${{ env.BODY }}
+          name: ${{ env.TITLE }}
+          prerelease: ${{ env.IS_PRERELEASE }}
+          allowUpdates: true


### PR DESCRIPTION
Implement nightly releases that are automatically updated when changes to the main branch are made.

![Screenshot_20230912_045520](https://github.com/webui-dev/webui/assets/34311583/32071bfb-c258-4e10-bc54-1b3442361b84)


This change should work very well as it is, but there are always improvements to make.

E.g. possible future improvements:
- Making releases could be split into it's own `release` workflow and file. This would require some re-organisation, since artifacts would need to be downloaded to make them accessible for a separate job and the release preparation would need to be done there, after downloading.
- What triggers a nightly release could be narrowed down further to changes that are decided to be relevant (the separate workflow mentioned above would be supplementary for this). 