### PR TITLE
Update text editor example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## Showcase
 
-This [text editor example](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor) is written in C using WebUI as the GUI library. The final executable is portable and has less than _1 MB_ in size (_+html and css files_).
+This [text editor](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor) is a lightweight and portable example written in C using WebUI as the GUI library.
 
 <div align="center">
 

--- a/examples/C/README.md
+++ b/examples/C/README.md
@@ -40,4 +40,4 @@ To build an example, cd into its directory and run the make command.
 
 ## Additional Examples
 
-- [`text-editor`](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor): Example of a text editor written in C using WebUI as the GUI library. The final executable is portable and has less than _1 MB_ in size (_+html and css files_).
+- [`text-editor`](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor): A lightweight and portable text editor written in C using WebUI as the GUI library.

--- a/examples/C/text-editor/README.md
+++ b/examples/C/text-editor/README.md
@@ -1,8 +1,10 @@
 # WebUI C - Text Editor
 
-This [text editor example](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor) is written in C using WebUI as the GUI library.
+This [text editor](https://github.com/webui-dev/webui/tree/main/examples/C/text-editor) is a lightweight and portable example written in C using WebUI as the GUI library.
 
-![webui_c_example](https://github.com/webui-dev/webui/assets/34311583/d024b22a-6330-4970-875a-e7d015d43595)
+<div align="center">
+  <img alt="Example" src="https://github.com/webui-dev/webui/assets/34311583/45bc85c7-b111-44b7-9aa6-80e861e7b47d">
+</div>
 
 - **Windows**
 


### PR DESCRIPTION
A change suggestion based on recent conversations and updates.

The statement next to the text-editor example `The final executable is portable and has less than _1 MB_ in size (_+html and css files_).` was recently removed at certain places. Now, the relevant parts are updated to `[...] is a lightweight and portable example written in C using WebUI as the GUI library.`
Hoping to prevent misconceptions about portability of the executable and size of the editor, while keeping the essence of the statement.

The screenshot in the text-editor examples README was update to the Windows screenshot used on the website. 

https://github.com/ttytm/webui/tree/examples/update-text-editor-screenshot/examples/C/text-editor

If the screenshot in the main README should also be updated or something should be changed, please let me know.