### PR TITLE
Fix clang build in Linux CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,11 +49,11 @@ jobs:
       - name: Build Debug Target
         run: |
           compiler=${{ matrix.compiler }}
-          make COMPILER=${compiler,,} debug
+          make CC=${compiler,,} debug
       - name: Build Release Target
         run: |
           compiler=${{ matrix.compiler }}
-          make COMPILER=${compiler,,}
+          make CC=${compiler,,}
       - name: Prepare Artifact
         run: |
           cp -r include dist


### PR DESCRIPTION
Currently, it falls back to default GCC.