### PR TITLE
Add `ChromiumBased` to `webui_browsers` enum

### DIFF
--- a/include/webui.h
+++ b/include/webui.h
@@ -115,6 +115,7 @@ enum webui_browsers {
     Vivaldi, // 8. The Vivaldi Browser
     Epic, // 9. The Epic Browser
     Yandex, // 10. The Yandex Browser
+    ChromiumBased, // 11. Any Chromium based browser
 };
 
 enum webui_runtimes {

--- a/src/webui.c
+++ b/src/webui.c
@@ -3914,7 +3914,7 @@ static bool _webui_browser_start(_webui_window_t* win, const char* address, size
     #endif
 
     // Non existing browser
-    if(browser > 10)
+    if(browser > 11)
         return false;
     
     // Current browser used in the last opened window
@@ -3923,7 +3923,20 @@ static bool _webui_browser_start(_webui_window_t* win, const char* address, size
 
     // TODO: Convert address from [/...] to [file://...]
 
-    if(browser != 0) {
+    if(browser == ChromiumBased) {
+
+        // Open the window using a Chromium based browser
+
+        if(!_webui_browser_start_chromium(win, address))
+            if(!_webui_browser_start_chrome(win, address))
+                if(!_webui_browser_start_edge(win, address))
+                    if(!_webui_browser_start_brave(win, address))
+                        if(!_webui_browser_start_vivaldi(win, address))
+                            if(!_webui_browser_start_epic(win, address))
+                                if(!_webui_browser_start_yandex(win, address))
+                                    return false;
+    }
+    else if(browser != 0) {
 
         // Open the window using the user specified browser
 


### PR DESCRIPTION
Chromium based browser share the same api.
So I'm running into the use case and that might be common to just use a chromium based browser, no matter which one specifically.

This PR would add a `ChromiumBased` enum field to use a any chromium based browser.

