### PR TITLE
Fix disabling translate feature on Chromium based browsers

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -3571,6 +3571,7 @@ static int _webui_get_browser_args(_webui_window_t* win, size_t browser, char *b
         "--disable-plugins",
         "--disable-plugins-discovery",
         "--disable-translate",
+        "--disable-features=Translate",
         "--bwsi",
         "--disable-sync",
         "--disable-sync-preferences",


### PR DESCRIPTION
"--disable-translate" doesnt work since few years. For Chrome to offer a translation just refresh the WebUI with Ctrl+R (maybe several times). The text in the browser must be in a language different than yours of course.

"--disable-features=Translate" fixes it, but I would keep "--disable-translate" too.

![wB8f4Yszoy](https://github.com/webui-dev/webui/assets/21068718/32fad1de-b6f0-4645-9bff-b681df0fe6a5)
