### PR TITLE
Improve text editor example

### DIFF
--- a/examples/C/text-editor/text-editor.c
+++ b/examples/C/text-editor/text-editor.c
@@ -18,11 +18,11 @@ int main() {
     webui_set_root_folder(MainWindow, "ui");
 
     // Bind HTML elements with the specified ID to C functions
-    webui_bind(MainWindow, "close-button", Close);
+    webui_bind(MainWindow, "__close-btn", Close);
 
     // Show the window, preferably in a chromium based browser
-    if (!webui_show_browser(MainWindow, "MainWindow.html", ChromiumBased))
-        webui_show(MainWindow, "MainWindow.html");
+    if (!webui_show_browser(MainWindow, "index.html", ChromiumBased))
+        webui_show(MainWindow, "index.html");
 
     // Wait until all windows get closed
     webui_wait();

--- a/examples/C/text-editor/ui/css/style.css
+++ b/examples/C/text-editor/ui/css/style.css
@@ -24,43 +24,36 @@ header {
 /* Nav */
 
 nav {
-    margin: 0 auto;
-    padding: 0px;
-    text-shadow: 1px 1px 2px #000000;
-    position: relative;
-    z-index: 99;
-    font-family: 'Font Awesome 5 Free';
-    font-size: 18px;
-}
-
-nav ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    text-align: center;
     background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 25%, rgba(255, 255, 255, 0.2) 75%, rgba(255, 255, 255, 0) 100%);
     box-shadow: 0 0 25px rgba(0, 0, 0, 0.1), inset 0 0 1px rgba(255, 255, 255, 0.6);
+    text-align: center;
+}
+
+nav button {
+    background: none;
+    border: none;
+    text-shadow: 1px 1px 2px #000000;
+    font-family: 'Font Awesome 5 Free';
+    font-size: 18px;
+    color: #ddecf9;
     cursor: pointer;
-}
-
-nav ul li {
-    display: inline-block;
-}
-
-nav ul li a {
+    margin: 0 auto;
     padding: 18px;
-    font-family: "Open Sans";
-    text-transform:uppercase;
-    text-decoration: none;
-    display: block;
 }
 
-nav ul li a i {
-    pointer-events: none;
-}
-
-nav ul li a:hover {
+nav button:hover {
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1), inset 0 0 1px rgba(255, 255, 255, 0.6);
     background: rgba(255, 255, 255, 0.1);
+}
+
+nav #save-btn:disabled {
+    pointer-events: none;
+    color: #7ca0df;
+}
+
+nav button i {
+    /* Click through the icon in the button */
+    pointer-events: none;
 }
 
 /* Code */

--- a/examples/C/text-editor/ui/index.html
+++ b/examples/C/text-editor/ui/index.html
@@ -1,33 +1,23 @@
 <!doctype html>
 <html>
     <head>
-        <meta charset="UTF-8">
+        <meta charset="UTF-8" />
         <script src="/webui.js"></script>
 
         <link rel="icon" type="image/png" href="img/icon.png" />
         <title>Text Editor in C using WebUI</title>
-        <link rel="stylesheet" href="css/style.css">
-        <link rel="stylesheet" href="css/lucario.css">
-        <link rel="stylesheet" href="css/codemirror.min.css">
-        <link rel="stylesheet" href="css/all.min.css">
+        <link rel="stylesheet" href="css/style.css" />
+        <link rel="stylesheet" href="css/lucario.css" />
+        <link rel="stylesheet" href="css/codemirror.min.css" />
+        <link rel="stylesheet" href="css/all.min.css" />
     </head>
     <body>
         <div class="topbar"></div>
         <nav>
-            <ul>
-                <li>
-                    <a onclick="OpenFile();"><i class="fas fa-folder-open"></i></a>
-                </li>
-                <li id="save-button" style="pointer-events: none; color: #7ca0df;">
-                    <a onclick="SaveFile();"><i class="fa fa-floppy-disk"></i></a>
-                </li>
-                <li>
-                    <a id="close-button"><i class="fas fa-circle-xmark"></i></a>
-                </li>
-                <li>
-                    <a id="about-button"><i class="fas fa-question-circle"></i></a>
-                </li>
-            </ul>
+            <button id="open-btn" title="Open file" type="button"><i class="fas fa-folder-open"></i></button>
+            <button id="save-btn" title="Save file" type="button" disabled><i class="fa fa-floppy-disk"></i></button>
+            <button id="__close-btn" title="Close file" type="button"><i class="fas fa-circle-xmark"></i></button>
+            <button id="about-btn" title="About Info" type="button"><i class="fas fa-question-circle"></i></button>
         </nav>
         <div class="main" id="main">
             <textarea id="editor"></textarea>

--- a/examples/C/text-editor/ui/js/ui.js
+++ b/examples/C/text-editor/ui/js/ui.js
@@ -1,34 +1,28 @@
 // Text Editor
 
 // Elements
-const aboutBtn = document.getElementById('about-button');
+const saveBtn = document.getElementById('save-btn');
 const aboutBox = document.getElementById('about-box');
-const saveBtn = document.getElementById('save-button');
+
+// File Handling
 const supportsFilePicker = 'showSaveFilePicker' in window;
 let fileHandle;
-let openFile = {
-    name: '',
-    ext: '',
-};
+let currentFile = { name: '', ext: '' };
 
-// About show
-aboutBtn.onclick = () => (aboutBox.style.display = 'block');
-// About hide
-aboutBox.onclick = () => (aboutBox.style.display = 'none');
+// Setup Editor
+const codeMirrorInstance = CodeMirror.fromTextArea(
+    document.getElementById('editor'),
+    {
+        mode: 'text/x-csrc',
+        lineNumbers: true,
+        tabSize: 4,
+        indentUnit: 2,
+        lineWrapping: true,
+        theme: 'lucario',
+    },
+);
 
-// Create the editor
-const editor = document.getElementById('editor');
-const codeMirrorInstance = CodeMirror.fromTextArea(editor, {
-    mode: 'text/x-csrc',
-    lineNumbers: true,
-    tabSize: 4,
-    indentUnit: 2,
-    lineWrapping: true,
-    theme: 'lucario',
-});
-
-// Change editor language
-function SetFileModeExtension(extension) {
+function setLanguage(extension) {
     let mode = '';
     switch (extension) {
         case 'js':
@@ -51,29 +45,23 @@ function SetFileModeExtension(extension) {
     codeMirrorInstance.setOption('mode', mode);
 }
 
-// Add full text to the editor
-function addText(text) {
-    codeMirrorInstance.setValue(text);
-
-    saveBtn.style.color = '#ddecf9';
-    saveBtn.style.pointerEvents = 'all';
+function setFile(file) {
+    currentFile.name = file.name;
+    currentFile.ext = file.name.split('.').pop();
+    // Set file title and language in editor
+    document.title = file.name;
+    setLanguage(currentFile.ext);
 }
 
 function readFile(file) {
     const reader = new FileReader();
-    reader.onload = (e) => addText(e.target.result);
+    // Add text to the editor
+    reader.onload = (e) => codeMirrorInstance.setValue(e.target.result);
     reader.readAsText(file);
+    saveBtn.disabled = false;
 }
 
-function setFile(file) {
-    openFile.name = file.name;
-    openFile.ext = file.name.split('.').pop();
-    // Set file title and language in editor
-    document.title = file.name;
-    SetFileModeExtension(openFile.ext);
-}
-
-async function OpenFile() {
+async function openFile() {
     if (supportsFilePicker) {
         [fileHandle] = await showOpenFilePicker({ multiple: false });
         fileData = await fileHandle.getFile();
@@ -91,7 +79,7 @@ async function OpenFile() {
     }
 }
 
-async function SaveFile() {
+async function saveFile() {
     const content = codeMirrorInstance.getValue();
     if (supportsFilePicker && fileHandle) {
         // Create a FileSystemWritableFileStream to write to
@@ -102,7 +90,7 @@ async function SaveFile() {
     } else {
         // Download the file if using filePicker with a fileHandle for saving
         // is not supported by the browser. E.g., in Firefox.
-        const blobData = new Blob([content], { type: 'text/${openFile.ext}' });
+        const blobData = new Blob([content], { type: 'text/${currentFile.ext}' });
         const urlToBlob = window.URL.createObjectURL(blobData);
         const a = document.createElement('a');
         a.style.setProperty('display', 'none');
@@ -114,6 +102,17 @@ async function SaveFile() {
     }
 }
 
+// Navigation Events
+// open
+document.getElementById('open-btn').onclick = openFile;
+// save
+saveBtn.onclick = saveFile;
+// about
+document.getElementById('about-btn').onclick = () =>
+    (aboutBox.style.display = 'block'); // show
+aboutBox.onclick = () => (aboutBox.style.display = 'none'); // hide
+
+// Editor events
 window.addEventListener('DOMContentLoaded', () => {
     codeMirrorInstance.setSize('100%', '99%');
 });

--- a/examples/C/text-editor/ui/js/ui.js
+++ b/examples/C/text-editor/ui/js/ui.js
@@ -58,7 +58,6 @@ function readFile(file) {
     // Add text to the editor
     reader.onload = (e) => codeMirrorInstance.setValue(e.target.result);
     reader.readAsText(file);
-    saveBtn.disabled = false;
 }
 
 async function openFile() {
@@ -100,6 +99,7 @@ async function saveFile() {
         window.URL.revokeObjectURL(urlToBlob);
         a.remove();
     }
+    saveBtn.disabled = true;
 }
 
 // Navigation Events
@@ -112,7 +112,11 @@ document.getElementById('about-btn').onclick = () =>
     (aboutBox.style.display = 'block'); // show
 aboutBox.onclick = () => (aboutBox.style.display = 'none'); // hide
 
-// Editor events
+// Editor Events
+// enable save on change
+codeMirrorInstance.on('change', () => {
+    saveBtn.disabled = false;
+});
 window.addEventListener('DOMContentLoaded', () => {
     codeMirrorInstance.setSize('100%', '99%');
 });

--- a/examples/C/text-editor/ui/js/ui.js
+++ b/examples/C/text-editor/ui/js/ui.js
@@ -80,12 +80,18 @@ async function openFile() {
 
 async function saveFile() {
     const content = codeMirrorInstance.getValue();
-    if (supportsFilePicker && fileHandle) {
-        // Create a FileSystemWritableFileStream to write to
-        const writableStream = await fileHandle.createWritable();
-        await writableStream.write(content);
-        // Write to disk
-        await writableStream.close();
+    if (supportsFilePicker) {
+        if (fileHandle) {
+            // Create a FileSystemWritableFileStream to write to
+            const writableStream = await fileHandle.createWritable();
+            await writableStream.write(content);
+            // Write to disk
+            await writableStream.close();
+        } else {
+            fileHandle = await showSaveFilePicker();
+            saveFile();
+            setFile(await fileHandle.getFile());
+        }
     } else {
         // Download the file if using filePicker with a fileHandle for saving
         // is not supported by the browser. E.g., in Firefox.


### PR DESCRIPTION
Two improvements are made. Currently, saving a file is only enabled when a file is opened. This is accompanied by that it is not possible to save text that is simply typed into the editor - without a file having been opened before.

The PR:
- Enables the save button when a change is made in the editor. It will also be disabled again after saving a file until the next change is made.
- Allows saving text entered in the editor when no file has been opened and sets the file data (doctitle and language) after saving.
- Makes some minor refactors.

