### PR TITLE
Create mac archive before uploading

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,6 +50,8 @@ jobs:
           cp -r include dist
           # Add the ARTIFACT name(lowercased) as GitHub environment variable.
           artifact=webui-$(echo ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
+          chmod -x dist/webui-2.dylib
+          chmod -x dist/debug/webui-2.dylib
           mv dist/ $artifact
           tar -czvf $artifact.tar.gz $artifact
           # Add the artifact name as GitHub environment variable for usage in later steps.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,26 +42,18 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}-bridge
           fail-on-cache-miss: true
       - name: Build Debug Target
-        run: |
-          if [ ${{ matrix.arch }} == arm64 ]; then
-            make ARCH_TARGET=${{ matrix.arch }} debug
-          else
-            make debug
-          fi
+        run: make ARCH_TARGET=${{ matrix.arch }} debug
       - name: Build Release Target
-        run: |
-          if [ ${{ matrix.arch }} == arm64 ]; then
-            make ARCH_TARGET=${{ matrix.arch }}
-          else
-            make
-          fi
+        run: make ARCH_TARGET=${{ matrix.arch }}
       - name: Prepare Artifacts
         run: |
           cp -r include dist
           # Add the ARTIFACT name(lowercased) as GitHub environment variable.
           artifact=webui-$(echo ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.arch }} | tr '[:upper:]' '[:lower:]')
-          echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
+          tar -czvf $artifact.tar.gz $artifact
+          # Add the artifact name as GitHub environment variable for usage in later steps.
+          echo "ARTIFACT=$artifact" >> $GITHUB_ENV
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -70,7 +62,6 @@ jobs:
       - name: Prepare Release
         if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
         run: |
-          tar -czvf ${{ env.ARTIFACT }}.tar.gz ${{ env.ARTIFACT }}
           if [ $GITHUB_REF_TYPE == tag ]; then
             echo "TAG=$GITHUB_REF_NAME" >> $GITHUB_ENV
           else


### PR DESCRIPTION
Reverts the recent PR, that had no effect on the outcome.

Creates the compressed archive before uploading as an attempt to solve an issue for macos-x64 where the uploaded release archive seems to get corrupted. In case the upload action has an effect on the later archived files this should prevent it.