### PR TITLE
Disable linting CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
     permissions:
       contents: write
 
-  lint:
-    uses: ./.github/workflows/lint.yml
+  # lint:
+  #   uses: ./.github/workflows/lint.yml


### PR DESCRIPTION
Disables the lint if that's desired.

I didn't experiences such common linters as issue before in other projects and the tools are available for all platform and usually every editor by default. If there is a configuration issue I might can help. Else feel free to disable 👍 