### PR TITLE
Fix macos artifact upload

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT }}
-          path: ${{ env.ARTIFACT }}.zip
+          path: ${{ env.ARTIFACT }}
       - name: Prepare Release
         if: github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push')
         run: |


### PR DESCRIPTION
Fixes artifact upload regression (https://github.com/webui-dev/webui/commit/c79f499e5b947943dd0bdb1c795671a31eba0271) for macos builds.

The default of upload-artifact is a zip. With the change it is similar to the linux workflow
https://github.com/webui-dev/webui/blob/ac4ea8cd7b11daf3d96c65db03e6c02e1e0bd6d2/.github/workflows/linux.yml#L89-L93
