### PR TITLE
Optimizing the build process

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,7 +114,6 @@ fn build_examples(b: *Build, optimize: OptimizeMode, target: CrossTarget, webui_
                         log.err("fmt path for examples failed, err is {}", .{err});
                         std.os.exit(1);
                     };
-                    // TODO: fix this
                     exe_run.cwd = cwd;
                 }
 
@@ -123,7 +122,7 @@ fn build_examples(b: *Build, optimize: OptimizeMode, target: CrossTarget, webui_
                     std.os.exit(1);
                 };
 
-                const step_desc = std.fmt.allocPrint(b.allocator, "run_{s}", .{example_name}) catch |err| {
+                const step_desc = std.fmt.allocPrint(b.allocator, "run exmaple {s}", .{example_name}) catch |err| {
                     log.err("fmt step_desc for examples failed, err is {}", .{err});
                     std.os.exit(1);
                 };


### PR DESCRIPTION
Optimizing the build process, we can now use zig to build all C examples

Like this:

```sh
❯ zig build --help

Usage: /usr/lib/zig/zig build [steps] [options]

Steps:
  install (default)            Copy build artifacts to prefix path
  uninstall                    Remove build artifacts from prefix path
  build_all                    build all examples
  run_call_js_from_c           run exmaple call_js_from_c
  run_public_network_access    run exmaple public_network_access
  run_call_c_from_js           run exmaple call_c_from_js
  run_text-editor              run exmaple text-editor
  run_custom_web_server        run exmaple custom_web_server
  run_serve_a_folder           run exmaple serve_a_folder
  run_minimal                  run exmaple minimal

```