### PR TITLE
fix: too few arguments to webui_set_profile

### DIFF
--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -199,7 +199,7 @@ class window {
 
     // Set the web browser proxy to use. Need to be called before `webui_show()`.
     void set_proxy(const std::string_view proxy_server = {""}) const {
-        webui_set_profile(webui_window, proxy_server.data());
+        webui_set_proxy(webui_window, proxy_server.data());
     }
 
     // Get the full current URL


### PR DESCRIPTION
When following the C++ hello world tutorial, the first example
immediately fails to compile due to an error in hte C++ header file.

```
In file included from main.cpp:1:
webui.hpp: In member function ‘void webui::window::set_proxy(std::string_view) const’:
webui.hpp:202:26: error: too few arguments to function ‘void webui_set_profile(size_t, const char*, const char*)’
  202 |         webui_set_profile(webui_window, proxy_server.data());
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from webui.hpp:21:
webui.h:422:19: note: declared here
  422 | WEBUI_EXPORT void webui_set_profile(size_t window, const char* name, const char* path);
```
