### PR TITLE
Headers and debug improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ TLS_LDFLAG_DYNAMIC = libssl.lib libcrypto.lib
 CIVETWEB_BUILD_FLAGS = /Fo"civetweb.obj" /c /EHsc "$(MAKEDIR)/src/civetweb/civetweb.c" /I"$(MAKEDIR)/src/civetweb/" /I"$(WEBUI_TLS_INCLUDE)"
 CIVETWEB_DEFINE_FLAGS = /D NDEBUG /D NO_CACHING /D NO_CGI /D USE_WEBSOCKET $(TLS_CFLAG)
 WEBUI_BUILD_FLAGS = /Fo"webui.obj" /c /EHsc "$(MAKEDIR)/src/webui.c" /I"$(MAKEDIR)/include" /I"$(WEBUI_TLS_INCLUDE)" $(TLS_CFLAG)
+VS_DEBUG_ARGS = /ZI /Zf /FS /JMC
 
 # Output Commands
 LIB_STATIC_OUT = /OUT:"$(WEBUI_OUT_LIB_NAME)-static.lib" "webui.obj" "civetweb.obj"
@@ -35,19 +36,17 @@ debug:
 #	Static with Debug info
 	@- cd $(MAKEDIR)/dist/debug
 	@echo Build WebUI Library (MSVC Debug Static)...
-	@cl /Zl /Zi $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
-	@cl /Zl /Zi $(WEBUI_BUILD_FLAGS) /D WEBUI_LOG
+	@cl /Zl $(VS_DEBUG_ARGS) $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
+	@cl /Zl $(VS_DEBUG_ARGS) $(WEBUI_BUILD_FLAGS) /D WEBUI_LOG
 	@lib $(LIB_STATIC_OUT)
 #	Dynamic with Debug info
 	@echo Build WebUI Library (MSVC Debug Dynamic)...
-	@cl /Zi $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
-	@cl /Zi $(WEBUI_BUILD_FLAGS) /D WEBUI_LOG
-	@link $(LIB_DYN_OUT)
+	@cl $(VS_DEBUG_ARGS) $(CIVETWEB_BUILD_FLAGS) $(CIVETWEB_DEFINE_FLAGS)
+	@cl $(VS_DEBUG_ARGS) $(WEBUI_BUILD_FLAGS) /D WEBUI_LOG
+	@link /DEBUG $(LIB_DYN_OUT)
 #	Clean
-	@- del *.pdb >nul 2>&1
 	@- del *.obj >nul 2>&1
 	@- del *.ilk >nul 2>&1
-	@- del *.pdb >nul 2>&1
 	@- del *.exp >nul 2>&1
 	@echo Done.
 

--- a/include/webui.h
+++ b/include/webui.h
@@ -144,6 +144,7 @@ typedef struct webui_event_t {
     const char* element; // HTML element ID
     size_t event_number; // Internal WebUI
     size_t bind_id;      // Bind ID
+	size_t magic_cookie; // used for event valid tracking
 } webui_event_t;
 
 // -- Definitions ---------------------

--- a/include/webui.h
+++ b/include/webui.h
@@ -141,7 +141,7 @@ enum webui_events {
 typedef struct webui_event_t {
     size_t window;       // The window object number
     size_t event_type;   // Event type
-    char* element;       // HTML element ID
+    const char* element; // HTML element ID
     size_t event_number; // Internal WebUI
     size_t bind_id;      // Bind ID
 } webui_event_t;
@@ -726,7 +726,8 @@ WEBUI_EXPORT void webui_return_bool(webui_event_t* e, bool b);
  * @example size_t id = webui_interface_bind(myWindow, "myID", myCallback);
  */
 WEBUI_EXPORT size_t webui_interface_bind(size_t window, const char* element,
-    void (*func)(size_t, size_t, char*, size_t, size_t));
+    void (*func)(size_t window, size_t event_type, const char* element, size_t event_number, size_t bind_id));
+
 
 /**
  * @brief When using `webui_interface_bind()`, you may need this function to easily set a response.

--- a/src/webui.c
+++ b/src/webui.c
@@ -93,6 +93,8 @@
 #else
 #define WEBUI_OS "GNU/Linux"
 #endif
+#define MAGIC_COOKIE 0xEBEBBE
+#define INVALID_COOKIE 0xFEEEFE
 
 // Mutex
 #ifdef _WIN32
@@ -1169,6 +1171,7 @@ size_t webui_bind(size_t window, const char* element, void( * func)(webui_event_
 
 const char* webui_get_string_at(webui_event_t* e, size_t index) {
 
+    assert(e->magic_cookie == MAGIC_COOKIE);
     #ifdef WEBUI_LOG
     printf("[User] webui_get_string_at([%zu])...\n", index);
     #endif
@@ -1252,6 +1255,7 @@ size_t webui_get_size_at(webui_event_t* e, size_t index) {
     printf("[User] webui_get_size_at([%zu])...\n", index);
     #endif
 
+    assert(e->magic_cookie == MAGIC_COOKIE);
     // Initialization
     _webui_init();
 
@@ -1313,6 +1317,7 @@ void webui_return_int(webui_event_t* e, long long int n) {
     printf("[User] webui_return_int([%lld])...\n", n);
     #endif
 
+    assert(e->magic_cookie == MAGIC_COOKIE);
     // Initialization
     _webui_init();
 
@@ -1345,6 +1350,7 @@ void webui_return_string(webui_event_t* e, const char* s) {
     printf("[User] webui_return_string([%s])...\n", s);
     #endif
 
+    assert(e->magic_cookie == MAGIC_COOKIE);
     if (_webui_is_empty(s))
         return;
 
@@ -1380,6 +1386,7 @@ void webui_return_bool(webui_event_t* e, bool b) {
     printf("[User] webui_return_bool([%d])...\n", b);
     #endif
 
+    assert(e->magic_cookie == MAGIC_COOKIE);
     // Initialization
     _webui_init();
 
@@ -2268,6 +2275,7 @@ static void _webui_interface_bind_handler(webui_event_t* e) {
     printf("[Core]\t\t_webui_interface_bind_handler()...\n");
     #endif
 
+    assert(e->magic_cookie == MAGIC_COOKIE);
     // Initialization
     _webui_init();
 
@@ -2367,6 +2375,7 @@ const char* webui_interface_get_string_at(size_t window, size_t event_number, si
     e.element = NULL;
     e.event_number = event_number;
     e.bind_id = 0;
+    e.magic_cookie = MAGIC_COOKIE;
 
     return webui_get_string_at(&e, index);
 }
@@ -2384,6 +2393,7 @@ long long int webui_interface_get_int_at(size_t window, size_t event_number, siz
     e.element = NULL;
     e.event_number = event_number;
     e.bind_id = 0;
+    e.magic_cookie = MAGIC_COOKIE;
 
     return webui_get_int_at(&e, index);
 }
@@ -2401,6 +2411,7 @@ bool webui_interface_get_bool_at(size_t window, size_t event_number, size_t inde
     e.element = NULL;
     e.event_number = event_number;
     e.bind_id = 0;
+    e.magic_cookie = MAGIC_COOKIE;
 
     return webui_get_bool_at(&e, index);
 }
@@ -2418,6 +2429,7 @@ size_t webui_interface_get_size_at(size_t window, size_t event_number, size_t in
     e.element = NULL;
     e.event_number = event_number;
     e.bind_id = 0;
+    e.magic_cookie = MAGIC_COOKIE;
 
     return webui_get_size_at(&e, index);
 }
@@ -2442,6 +2454,7 @@ void webui_interface_set_response(size_t window, size_t event_number, const char
     printf("[User] webui_interface_set_response() -> Response [%s] \n", response);
     #endif
 
+    assert(event_number < WEBUI_MAX_IDS);
     // Initialization
     _webui_init();
 
@@ -6041,6 +6054,7 @@ static void _webui_window_event(
     e.event_type = event_type;
     e.element = element;
     e.event_number = event_number;
+    e.magic_cookie = MAGIC_COOKIE;
 
     // Check for all events-bind functions
     if (!_webui_mtx_is_exit_now(WEBUI_MUTEX_NONE) && win->has_events) {
@@ -6082,6 +6096,7 @@ static void _webui_window_event(
     #ifdef WEBUI_LOG
     printf("[Core]\t\t_webui_window_event() -> Finished.\n");
     #endif
+    e.magic_cookie = INVALID_COOKIE;
 }
 
 static void _webui_ws_send(_webui_window_t * win, char* packet, size_t packets_size) {
@@ -7560,6 +7575,7 @@ static WEBUI_THREAD_RECEIVE {
                             e.event_type = WEBUI_EVENT_CALLBACK;
                             e.element = element;
                             e.event_number = event_num;
+                            e.magic_cookie = MAGIC_COOKIE;
 
                             // Call user function
                             size_t cb_index = _webui_get_cb_index(webui_internal_id);
@@ -7598,7 +7614,8 @@ static WEBUI_THREAD_RECEIVE {
                                 win, win->token, packet_id, WEBUI_CMD_CALL_FUNC,
                                 event_inf->response, _webui_strlen(event_inf->response)
                             );
-
+                            e.magic_cookie = INVALID_COOKIE;
+                            
                             // Free event
                             _webui_free_mem((void * ) event_inf->response);
                         } else {

--- a/src/webui.c
+++ b/src/webui.c
@@ -192,7 +192,7 @@ typedef struct _webui_core_t {
     uint16_t run_last_id;
     bool initialized;
     void( * cb[WEBUI_MAX_IDS])(webui_event_t* e);
-    void( * cb_interface[WEBUI_MAX_IDS])(size_t, size_t, char* , size_t, size_t);
+    void( * cb_interface[WEBUI_MAX_IDS])(size_t, size_t, const char* , size_t, size_t);
     char* executable_path;
     void * ptr_list[WEBUI_MAX_IDS * 2];
     size_t ptr_position;
@@ -278,7 +278,7 @@ static void _webui_free_port(size_t port);
 static char* _webui_get_current_path(void);
 static void _webui_ws_send(_webui_window_t * win, char* packet, size_t packets_size);
 static void _webui_window_event(
-    _webui_window_t * win, int event_type, char* element, size_t event_number, char* webui_internal_id
+    _webui_window_t * win, int event_type, const char* element, size_t event_number, char* webui_internal_id
 );
 static int _webui_cmd_sync(_webui_window_t * win, char* cmd, bool show);
 static int _webui_cmd_async(_webui_window_t * win, char* cmd, bool show);
@@ -2422,7 +2422,7 @@ size_t webui_interface_get_size_at(size_t window, size_t event_number, size_t in
     return webui_get_size_at(&e, index);
 }
 
-size_t webui_interface_bind(size_t window, const char* element, void( * func)(size_t, size_t, char* , size_t, size_t)) {
+size_t webui_interface_bind(size_t window, const char* element, void( * func)(size_t, size_t, const char* , size_t, size_t)) {
 
     #ifdef WEBUI_LOG
     printf("[User] webui_interface_bind([%zu], [%s], [0x%p])...\n", window, element, func);
@@ -5886,7 +5886,7 @@ static bool _webui_show_window(_webui_window_t * win, const char* content, int t
     sprintf(win->url, WEBUI_HTTP_PROTOCOL "localhost:%zu", win->server_port);
 
     // Generate the window URL
-    char* window_url = NULL;
+    const char* window_url = NULL;
     if (type == WEBUI_SHOW_HTML) {
 
         const char* user_html = content;
@@ -5896,8 +5896,9 @@ static bool _webui_show_window(_webui_window_t * win, const char* content, int t
         win->html = (user_html == NULL ? "" : user_html);
 
         // Set window URL
-        window_url = (char*)_webui_malloc(strlen(win->url));
-        strcpy(window_url, win->url);
+        char * url = (char*)_webui_malloc(strlen(win->url));
+        strcpy(url, win->url);
+        window_url = url;
     } else if (type == WEBUI_SHOW_URL) {
 
         const char* user_url = content;
@@ -6027,7 +6028,7 @@ static bool _webui_show_window(_webui_window_t * win, const char* content, int t
 }
 
 static void _webui_window_event(
-    _webui_window_t * win, int event_type, char* element, size_t event_number, char* webui_internal_id
+    _webui_window_t * win, int event_type, const char* element, size_t event_number, char* webui_internal_id
 ) {
 
     #ifdef WEBUI_LOG


### PR DESCRIPTION
This has 3 commits can submit them separately or remove any not wanted but some of the lines were too close to avoid conflicts otherwise.

Most of these changes are minor, adding better MSVC debug flags, switching some char* to const char* when they are const.   Adding names to the interface_bind function pointer.  In addition to making things a bit more clear it assists autogeneration of the code with a tool like CPPSharp.  More details on that below.

The final item that is here is adding a magic cookie to event structs.   I dislike the idea of expanding the struct to include a memory check but it is one of two ways I thought to do this effectively.    Events are only executed in serial one at a time and do not support callbacks.  This may make users more likely to use them in an async fashion and potentially try to set the result after they should (or call another function on them).   As we try to use the event ID directly this could cause use after free issues (but with something like interfaces may not be invalid due to the event buffer).   

I thought about just adding this with a DEBUG compile time flag, but changing the event struct size based on that seemed like a bad idea.   The only other option takes advantage of the serial call limitation.   We could store the pointer to the current event struct, and the current event's id (for interface callbacks).   We could then assert if the pointer/id number that come in don't match.   



### Auto Code Generation
 With these changes no modifications are needed to generate a fairly 1:1 api: https://github.com/mitchcapper/WebUIAutoBuild/blob/master/CodeGen/WebUIGeneratorDirect.cs

resulting in: https://github.com/mitchcapper/WebUIAutoBuild/blob/master/Generated/WebUI.cs

With a more complicated generator can generate it into a more standardized class form: https://github.com/mitchcapper/WebUIAutoBuild/blob/master/CodeGen/WebUIGeneratorClass.cs

I put together a quick sample for what each looks like when used at:
https://github.com/mitchcapper/WebUIAutoBuild/tree/master/ConsoleSampleApp

but for the class version its pretty spot on:


Note these were not to replace the actual c# lib ( https://github.com/Juff-Ma/WebUI.NET ) but I generated for some testing.