### PR TITLE
C++ events are now enum instead of const static int

### DIFF
--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -23,11 +23,13 @@ extern "C" {
 
 namespace webui {
 
-static constexpr int DISCONNECTED = 0; // 0. Window disconnection event
-static constexpr int CONNECTED = 1;    // 1. Window connection event
-static constexpr int MOUSE_CLICK = 2;  // 2. Mouse click event
-static constexpr int NAVIGATION = 3;   // 3. Window navigation event
-static constexpr int CALLBACKS = 4;    // 4. Function call event
+enum : int {
+    DISCONNECTED = 0, // 0. Window disconnection event
+    CONNECTED = 1,    // 1. Window connection event
+    MOUSE_CLICK = 2,  // 2. Mouse click event
+    NAVIGATION = 3,   // 3. Window navigation event
+    CALLBACKS = 4    // 4. Function call event
+};
 
 class window {
     private:


### PR DESCRIPTION
This pr is not intended to change API compatibility, in fact the C++ `example serve_a_folder` can be compiled without changes, but a larger discussion should be held about the status of enums for example:

- [Most enums are PascalCase without repetitions](https://github.com/webui-dev/webui/blob/24fefb865b2d8de188b3344981635c9f99a26dec/include/webui.h#L114C1-L128C3)
- [The event enum is uppercase snake_case with repetitions](https://github.com/webui-dev/webui/blob/24fefb865b2d8de188b3344981635c9f99a26dec/include/webui.h#L136-L142)
- [The event enum is of type enum(int), but is stored in a size_t](https://github.com/webui-dev/webui/blob/24fefb865b2d8de188b3344981635c9f99a26dec/include/webui.h#L147)
- [Language bindings sometimes redeclare enums with a different base type](https://github.com/webui-dev/zig-webui/blob/b734cf46341c11959698dfaf094193534852a51a/src/webui.zig#L23-L50)