### PR TITLE
change ubuntu version in linux workflow to support legacy glib

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Bundle WebUI Bridge


### PR DESCRIPTION
As discussed in [#321](https://github.com/webui-dev/webui/issues/321), the people who run WebUI on Ubuntu 20.04 or lower get the error of version `GLIBC_2.33' not found`  since they have `glibc 2.31`(for the case of Ubuntu 20.04) or lower. Currently, a workaround has to be used as explained [here](https://github.com/webui-dev/webui/issues/321#issuecomment-2075075790). To solve this problem, Ubuntu version in the linux workflow should be changed to `ubuntu-18.04` as proposed [here](https://github.com/webui-dev/webui/issues/321#issuecomment-1914961370).