### PR TITLE
Simplify building examples with Zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -116,6 +116,7 @@ fn build_examples_11(b: *Build, optimize: OptimizeMode, target: CrossTarget, web
         if (entry.kind != .directory) {
             continue;
         }
+
         const example_name = entry.name;
         const path = std.fmt.allocPrint(b.allocator, "examples/C/{s}/main.c", .{example_name}) catch |err| {
             log.err("fmt path for examples failed, err is {}", .{err});
@@ -127,23 +128,15 @@ fn build_examples_11(b: *Build, optimize: OptimizeMode, target: CrossTarget, web
             .target = target,
             .optimize = optimize,
         });
-
+        exe.linkLibrary(webui_lib);
         exe.addCSourceFile(.{
-            .file = .{
-                .path = path,
-            },
+            .file = .{ .path = path },
             .flags = &.{},
         });
 
-        exe.subsystem = .Windows;
-
-        exe.linkLibrary(webui_lib);
-
         const exe_install = b.addInstallArtifact(exe, .{});
-
-        build_all_step.dependOn(&exe_install.step);
-
         const exe_run = b.addRunArtifact(exe);
+        build_all_step.dependOn(&exe_install.step);
         exe_run.step.dependOn(&exe_install.step);
 
         const cwd = std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ examples_path, example_name }) catch |err| {
@@ -156,12 +149,10 @@ fn build_examples_11(b: *Build, optimize: OptimizeMode, target: CrossTarget, web
             log.err("fmt step_name for examples failed, err is {}", .{err});
             std.os.exit(1);
         };
-
         const step_desc = std.fmt.allocPrint(b.allocator, "run example {s}", .{example_name}) catch |err| {
             log.err("fmt step_desc for examples failed, err is {}", .{err});
             std.os.exit(1);
         };
-
         const exe_run_step = b.step(step_name, step_desc);
         exe_run_step.dependOn(&exe_run.step);
     } else |err| {

--- a/build.zig
+++ b/build.zig
@@ -112,60 +112,58 @@ fn build_examples_11(b: *Build, optimize: OptimizeMode, target: CrossTarget, web
     var itera = iter_dir.iterate();
 
     while (itera.next()) |val| {
-        if (val) |entry| {
-            if (entry.kind == .directory) {
-                const example_name = entry.name;
-                const path = std.fmt.allocPrint(b.allocator, "examples/C/{s}/main.c", .{example_name}) catch |err| {
-                    log.err("fmt path for examples failed, err is {}", .{err});
-                    std.os.exit(1);
-                };
-
-                const exe = b.addExecutable(.{
-                    .name = example_name,
-                    .target = target,
-                    .optimize = optimize,
-                });
-
-                exe.addCSourceFile(.{
-                    .file = .{
-                        .path = path,
-                    },
-                    .flags = &.{},
-                });
-
-                exe.subsystem = .Windows;
-
-                exe.linkLibrary(webui_lib);
-
-                const exe_install = b.addInstallArtifact(exe, .{});
-
-                build_all_step.dependOn(&exe_install.step);
-
-                const exe_run = b.addRunArtifact(exe);
-                exe_run.step.dependOn(&exe_install.step);
-
-                const cwd = std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ examples_path, example_name }) catch |err| {
-                    log.err("fmt path for examples failed, err is {}", .{err});
-                    std.os.exit(1);
-                };
-                exe_run.cwd = cwd;
-
-                const step_name = std.fmt.allocPrint(b.allocator, "run_{s}", .{example_name}) catch |err| {
-                    log.err("fmt step_name for examples failed, err is {}", .{err});
-                    std.os.exit(1);
-                };
-
-                const step_desc = std.fmt.allocPrint(b.allocator, "run example {s}", .{example_name}) catch |err| {
-                    log.err("fmt step_desc for examples failed, err is {}", .{err});
-                    std.os.exit(1);
-                };
-
-                const exe_run_step = b.step(step_name, step_desc);
-                exe_run_step.dependOn(&exe_run.step);
-            }
-        } else {
-            break;
+        const entry = val orelse break;
+        if (entry.kind != .directory) {
+            continue;
         }
+        const example_name = entry.name;
+        const path = std.fmt.allocPrint(b.allocator, "examples/C/{s}/main.c", .{example_name}) catch |err| {
+            log.err("fmt path for examples failed, err is {}", .{err});
+            std.os.exit(1);
+        };
+
+        const exe = b.addExecutable(.{
+            .name = example_name,
+            .target = target,
+            .optimize = optimize,
+        });
+
+        exe.addCSourceFile(.{
+            .file = .{
+                .path = path,
+            },
+            .flags = &.{},
+        });
+
+        exe.subsystem = .Windows;
+
+        exe.linkLibrary(webui_lib);
+
+        const exe_install = b.addInstallArtifact(exe, .{});
+
+        build_all_step.dependOn(&exe_install.step);
+
+        const exe_run = b.addRunArtifact(exe);
+        exe_run.step.dependOn(&exe_install.step);
+
+        const cwd = std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ examples_path, example_name }) catch |err| {
+            log.err("fmt path for examples failed, err is {}", .{err});
+            std.os.exit(1);
+        };
+        exe_run.cwd = cwd;
+
+        const step_name = std.fmt.allocPrint(b.allocator, "run_{s}", .{example_name}) catch |err| {
+            log.err("fmt step_name for examples failed, err is {}", .{err});
+            std.os.exit(1);
+        };
+
+        const step_desc = std.fmt.allocPrint(b.allocator, "run example {s}", .{example_name}) catch |err| {
+            log.err("fmt step_desc for examples failed, err is {}", .{err});
+            std.os.exit(1);
+        };
+
+        const exe_run_step = b.step(step_name, step_desc);
+        exe_run_step.dependOn(&exe_run.step);
     } else |err| {
         log.err("iterate examples_path failed, err is {}", .{err});
         std.os.exit(1);


### PR DESCRIPTION
It’s really handy to have the possibility to build with Zig; it provides everything so fast. I’m just getting into using it more now. Thanks for adding it @jinzhongjia .

The changes simplify building the examples. It removes two nesting levels by handling the "unhappy-path" early.