### PR TITLE
Update workflows, add zig build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
     uses: ./.github/workflows/linux.yml
     permissions:
       contents: write
+
+  zig:
+    uses: ./.github/workflows/zig.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
     branches: [main]
     paths-ignore: ['**/*.md']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     uses: ./.github/workflows/windows.yml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,13 +14,13 @@ jobs:
   setup:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Bundle WebUI Bridge
         run: |
           npm i -g esbuild
           chmod +x bridge/build.sh
           bridge/build.sh
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
@@ -41,8 +41,8 @@ jobs:
             arch: arm
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache/restore@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
         with:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
@@ -87,7 +87,7 @@ jobs:
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,13 +14,13 @@ jobs:
   setup:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Bundle WebUI Bridge
         run: |
           npm i -g esbuild
           chmod +x bridge/build.sh
           bridge/build.sh
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
@@ -35,8 +35,8 @@ jobs:
         compiler: [Clang]
         arch: [x64, arm64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache/restore@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
         with:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
@@ -53,7 +53,7 @@ jobs:
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/ $artifact
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,10 +14,10 @@ jobs:
   setup:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Bundle WebUI Bridge
         run: bridge/build.ps1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
@@ -32,13 +32,13 @@ jobs:
         compiler: [GCC, MSVC]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache/restore@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
         with:
           path: bridge/webui_bridge.h
           key: ${{ runner.os }}-${{ github.sha }}-bridge
           fail-on-cache-miss: true
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: microsoft/setup-msbuild@v2
       - if: matrix.compiler == 'MSVC'
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build Debug Target
@@ -68,7 +68,7 @@ jobs:
           echo "ARTIFACT=$artifact" >> $GITHUB_ENV
           mv dist/* $artifact/
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -1,4 +1,4 @@
-name: Zig
+name: Zig Build
 
 on:
   workflow_call:

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -1,0 +1,22 @@
+name: Zig
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.11.0
+      - name: Build libarary
+        run: zig build
+      - name: Build examples
+        run: zig build build_all


### PR DESCRIPTION
- Makes a maintenance update to the workflows, resolving deprecation warnings.
- Adds a concurrency group setting to prevent omit stacking unnecessary runs.
- Adds a workflow to test building the lib and examples with zig.