### PR TITLE
Extend test coverage, add CI steps to build C examples with make

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,6 +77,25 @@ jobs:
             compiler=${{ matrix.compiler }}
             make CC=${compiler,,}
           fi
+      - name: Build examples
+        if: matrix.arch == 'x64'
+        run: |
+          examples_base_dir=$(pwd)/examples/C
+          for example in $(find $examples_base_dir/* -maxdepth 0 -type d); do
+            echo "> $example"
+            cd $example || (exit_code=1 && continue)
+            if ! make; then
+               echo "Failed to build '$example'"
+               exit_code=1
+               continue
+            fi
+            if [[ ! -e "main" || ! -e "main-dyn" ]] ; then
+              echo "Failed to find executable for '$example'" && find .
+              exit_code=1
+              continue
+            fi
+          done
+          exit $exit_code
       - name: Prepare Artifact
         run: |
           cp -r include dist

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,6 +45,24 @@ jobs:
         run: make ARCH_TARGET=${{ matrix.arch }} debug
       - name: Build Release Target
         run: make ARCH_TARGET=${{ matrix.arch }}
+      - name: Build examples
+        run: |
+          examples_base_dir=$(pwd)/examples/C
+          for example in $(find $examples_base_dir/* -maxdepth 0 -type d); do
+            echo "> $example"
+            cd $example || (exit_code=1 && continue)
+            if ! make; then
+               echo "Failed to build '$example'"
+               exit_code=1
+               continue
+            fi
+            if [[ ! -e "main" || ! -e "main-dyn" ]] ; then
+              echo "Failed to find executable for '$example'" && find .
+              exit_code=1
+              continue
+            fi
+          done
+          exit $exit_code
       - name: Prepare Artifacts
         run: |
           cp -r include dist

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,36 @@ jobs:
           } else {
             mingw32-make
           }
+      - name: Build examples
+        run: |
+          $examples_base_dir = "$(Get-Location)/examples/C/"
+          foreach ($example in Get-ChildItem -Path $examples_base_dir -Directory) {
+              Write-Host "> $example"
+              Set-Location -Path $example.FullName
+              if (!$?) {
+                  $exit_code = 1
+                  continue
+              }
+              if ('${{ matrix.compiler }}' -eq 'MSVC') {
+                  $make_cmd = "nmake"
+              } else {
+                  $make_cmd = "mingw32-make"
+              }
+              $make_output = Invoke-Expression $make_cmd
+              if (!$?) {
+                  Write-Host "Failed to build '$example': $make_output"
+                  $exit_code = 1
+                  continue
+                }
+              Write-Output $make_output
+              if (!(Test-Path "main.exe") -or !(Test-Path "main-dyn.exe")) {
+                  Write-Host "Failed to find executable for '$example'"
+                  Get-ChildItem
+                  $exit_code = 1
+                  continue
+              }
+          }
+          exit $exit_code
       - name: Prepare Artifact
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,11 @@ jobs:
       contents: write
     strategy:
       matrix:
-        compiler: [GCC, MSVC]
+        include:
+          - compiler: GCC
+            make: mingw32-make
+          - compiler: MSVC
+            make: nmake
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -42,19 +46,9 @@ jobs:
       - if: matrix.compiler == 'MSVC'
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build Debug Target
-        run: |
-          if ('${{ matrix.compiler }}' -eq 'MSVC') {
-            nmake debug
-          } else {
-            mingw32-make debug
-          }
+        run: ${{ matrix.make }} debug
       - name: Build Release Target
-        run: |
-          if ('${{ matrix.compiler }}' -eq 'MSVC') {
-            nmake
-          } else {
-            mingw32-make
-          }
+        run: ${{ matrix.make }}
       - name: Build examples
         run: |
           $examples_base_dir = "$(Get-Location)/examples/C/"
@@ -65,12 +59,7 @@ jobs:
                   $exit_code = 1
                   continue
               }
-              if ('${{ matrix.compiler }}' -eq 'MSVC') {
-                  $make_cmd = "nmake"
-              } else {
-                  $make_cmd = "mingw32-make"
-              }
-              $make_output = Invoke-Expression $make_cmd
+              $make_output = Invoke-Expression ${{ matrix.make }}
               if (!$?) {
                   Write-Host "Failed to build '$example': $make_output"
                   $exit_code = 1


### PR DESCRIPTION
The PR should help to detect errors and ensure that users can continue to build examples.

Some extracted examples from a test run on the PR fork (for a full overview, please check the CI jobs below the PR):
|macOS|Windows|
|-|-|
|![Screenshot_20240528_180933](https://github.com/webui-dev/webui/assets/34311583/73cd39da-c50e-44c4-afed-25bba4d38ea5)|![Screenshot_20240528_181017](https://github.com/webui-dev/webui/assets/34311583/8b31ec04-eb2b-4395-8415-077c4c4bcdb2)|

