### PR TITLE
Update variable type in _webui_round_to_memory_block to resolve sing-comp warning

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,7 +37,7 @@ ARCH_TARGET ?=
 # BUILD FLAGS
 CIVETWEB_BUILD_FLAGS := -o civetweb.o -I"$(MAKEFILE_DIR)/include/" -c "$(MAKEFILE_DIR)/src/civetweb/civetweb.c" -I"$(WEBUI_TLS_INCLUDE)" $(TLS_CFLAG) -w
 CIVETWEB_DEFINE_FLAGS = -DNDEBUG -DNO_CACHING -DNO_CGI -DUSE_WEBSOCKET $(TLS_CFLAG)
-WEBUI_BUILD_FLAGS := -o webui.o -I"$(MAKEFILE_DIR)/include/" -c "$(MAKEFILE_DIR)/src/webui.c" -I"$(WEBUI_TLS_INCLUDE)" $(TLS_CFLAG) -w
+WEBUI_BUILD_FLAGS := -o webui.o -I"$(MAKEFILE_DIR)/include/" -c "$(MAKEFILE_DIR)/src/webui.c" -I"$(WEBUI_TLS_INCLUDE)" $(TLS_CFLAG) -Wsign-compare -Werror
 
 # OUTPUT FILES
 # The static output is the same for all platforms

--- a/src/webui.c
+++ b/src/webui.c
@@ -3188,11 +3188,11 @@ static size_t _webui_round_to_memory_block(size_t size) {
     // we should return the same block
     size--;
 
-    int block_size = 4;
+    size_t block_size = 4;
     while(block_size <= size)
         block_size *= 2;
 
-    return (size_t) block_size;
+    return block_size;
 }
 
 static void * _webui_malloc(size_t size) {


### PR DESCRIPTION
The PR enables sing-compare errors. And will attempt to solve some of them when there is time.

We should eventually resolve all the warnings/errors to follow best practices and to make things more robust.

Some of them already cause problems when trying to use webui source files directly with some C interop languages.

I think lots are easy fixes. If someone wants to append to this PR, we can do it as a tandem work. Or, if it is preferred to take one category of the errors and submit them as separate PR it will also be helpful.