### PR TITLE
Update linux webview positon fallback values values to match type dec…

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -9725,8 +9725,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         webView->url = url_copy;
         webView->width = (win->width > 0 ? win->width : 800);
         webView->height = (win->height > 0 ? win->height : 600);
-        webView->x = (win->x > 0 ? win->x : -1);
-        webView->y = (win->y > 0 ? win->y : -1);
+        webView->x = (win->x > 0 ? win->x : 0);
+        webView->y = (win->y > 0 ? win->y : 0);
         win->webView = webView;
 
         // New WebView window


### PR DESCRIPTION
Fixes a warning when compiling on Linux caused by the webview struct taking uints but passing a negative value:
```
src/webui.c: In function ‘_webui_wv_show’:
src/webui.c:9728:45: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘unsigned int’ due to unsignedness of other operand [-Wsign-compare]
 9728 |         webView->x = (win->x > 0 ? win->x : -1);
      |                                             ^~
src/webui.c:9729:45: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘unsigned int’ due to unsignedness of other operand [-Wsign-compare]
 9729 |         webView->y = (win->y > 0 ? win->y : -1);
      |                                             ^~
