### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,84 @@
+name: 🐛 Bug Report
+description: File a bug report.
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+      description: What happened? A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Providing a self-contained, concise code example that can be used to reproduce the issue.
+        Can help to solve the problem as fast as possible.
+
+        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+
+        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
+        The code sample should be an SSCCE. See http://sscce.org/ for details.
+        In short, please provide a code sample that we can copy/paste, run and reproduce.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      render: 'shell'
+      description: |
+        Please include full errors, uncaught exceptions, stack traces.
+        Trigger the issue with WebUI's debug build to add relevant logs.
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Possible Solution
+      description: If you can suggest fix, include a prototype/workaround/sketch/reference.
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please provide the current WebUI version you are using.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details (OS name and version, etc.)
+      render: shell
+      description: |
+        To fill in this section, you can use on Unix-like systems:
+        ```sh
+        uname -somr
+        ```
+        On Windows you can use:
+        ```sh
+        cmd /c wmic cpu get systemname,caption
+        ```
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: 💬 WebUI Community Support
+    url: https://github.com/webui-dev/webui/discussions
+    about: Please can ask and answer questions about WebUI here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,69 @@
+name: 🚀 Feature Request
+description: Suggest an idea for this project.
+labels: [enhancement]
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Feature
+      description: A clear and concise description of the feature you are proposing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Why do you need this feature?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Proposed Solution
+      description: If you can suggest how the addition or change can be implemented, include a prototype/workaround/sketch/reference implementation.
+    validations:
+      required: false
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: Any alternative solutions or features you considered, a more detailed explanation, stack traces, related issues, links for context, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: implementation
+    attributes:
+      label: Implementation
+      options:
+        - label: I may be able to implement the feature.
+        - label: It might incur a breaking change.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please provide the current WebUI version you are using.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details (OS name and version, etc.)
+      render: shell
+      description: |
+        To fill in this section, you can use on Unix-like systems:
+        ```sh
+        uname -somr
+        ```
+        On Windows you can use:
+        ```sh
+        cmd /c wmic cpu get systemname,caption
+        ```
+    validations:
+      required: true


### PR DESCRIPTION
The PR would add GitHub issue templates.

I've created some github form templates customized for the webui repositories.

- Rationale:
  Many reported issues are platform dependent, and the same questions are often asked after an issue is opened and require a response before work can be done to resolve it. The templates can guide a user to provide all the necessary information immediately so that issues can be resolved as quickly as possible.
  
If you want to test it, I've pushed it to the main fork branch to make it testable: https://github.com/ttytm/webui/issues. Start the issue creation / or finish it, I will delete the issues afterwards.

Suggestions are welcome.