### PR TITLE
Use semver compliant version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Logo](https://raw.githubusercontent.com/webui-dev/webui-logo/main/webui_240.png)
 
-# WebUI v2.5.0-Beta-1
+# WebUI v2.5.0-beta
 
 [build-status]: https://img.shields.io/github/actions/workflow/status/webui-dev/webui/ci.yml?branch=main&style=for-the-badge&logo=githubactions&labelColor=414868&logoColor=C0CAF5
 [last-commit]: https://img.shields.io/github/last-commit/webui-dev/webui?style=for-the-badge&logo=github&logoColor=C0CAF5&labelColor=414868

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,5 @@
 .{
     .name = "webui",
-    .version = "2.5.0-beta1",
-    .dependencies = .{},
+    .version = "2.5.0-beta",
     .paths = .{""},
 }

--- a/include/webui.h
+++ b/include/webui.h
@@ -1,5 +1,5 @@
 /*
-  WebUI Library 2.5.0-Beta-1
+  WebUI Library 2.5.0-beta
   http://webui.me
   https://github.com/webui-dev/webui
   Copyright (c) 2020-2024 Hassan Draga.
@@ -11,7 +11,7 @@
 #ifndef _WEBUI_H
 #define _WEBUI_H
 
-#define WEBUI_VERSION "2.5.0-Beta-1"
+#define WEBUI_VERSION "2.5.0-beta"
 
 // Max windows, servers and threads
 #define WEBUI_MAX_IDS (256)

--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -1,5 +1,5 @@
 /*
-  WebUI Library 2.5.0-Beta-1
+  WebUI Library 2.5.0-beta
   http://webui.me
   https://github.com/webui-dev/webui
   Copyright (c) 2020-2024 Hassan Draga.

--- a/src/webui.c
+++ b/src/webui.c
@@ -1,5 +1,5 @@
 /*
-  WebUI Library 2.5.0-Beta-1
+  WebUI Library 2.5.0-beta
   http://webui.me
   https://github.com/webui-dev/webui
   Copyright (c) 2020-2024 Hassan Draga.

--- a/src/webview/wkwebview.m
+++ b/src/webview/wkwebview.m
@@ -1,5 +1,5 @@
 /*
-  WebUI Library 2.5.0-Beta-1
+  WebUI Library 2.5.0-beta
   http://webui.me
   https://github.com/webui-dev/webui
   Copyright (c) 2020-2024 Hassan Draga.


### PR DESCRIPTION
Hoping this PR is not too pedantic, it would update the version specification.
It might pave the way for consistent future version specifications discussions are welcome.

Goals/Reasons: 
- Follow semver syntax more closely https://semver.org
- Currently, the development state is fairly fluent. It cannot really be pinned down to a version. A `2.5.0-beta` is more general than a `2.5.0-beta.1`.  
  I suggest making pre-release after #380 and #388
  Then a version and a tag like `2.5.0-beta.1` could be used and the state pinned down to this version. Else, until a `2.5.0` release keeping it general to just `2.5.0-beta` should be okay.
  
It still looks good rendered in the readme.