### PR TITLE
Update format specification in macos debug print

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -9950,7 +9950,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
 
     static bool _webui_wv_navigate(_webui_wv_macos_t* webView, char* url) {
         #ifdef WEBUI_LOG
-        printf("[Core]\t\t_webui_wv_navigate([%ls])\n", url);
+        printf("[Core]\t\t_webui_wv_navigate([%s])\n", url);
         #endif
         _webui_macos_wv_navigate(webView->index, (const char*)url);
         return false;


### PR DESCRIPTION
Makes a small update to the formatting specification for a type char*

This fixes the last error that we would run into if building with make on macos with `-Werror`.