### PR TITLE
Fix conflict with including dirent

### DIFF
--- a/include/webui.h
+++ b/include/webui.h
@@ -47,9 +47,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#if defined(__GNUC__) || defined(__TINYC__)
-    #include <dirent.h>
-#endif
 
 // -- Windows -------------------------
 #ifdef _WIN32
@@ -57,6 +54,9 @@
     #include <ws2tcpip.h>
     #ifndef WIN32_LEAN_AND_MEAN
         #define WIN32_LEAN_AND_MEAN
+    #endif
+    #if defined(__GNUC__) || defined(__TINYC__)
+        #include <dirent.h>
     #endif
     #include <windows.h>
     #include <direct.h>


### PR DESCRIPTION
The PR should resolved the last changed required to satisfy the go compiler when directly using WebUI as a submodule.

It will allow for: https://github.com/webui-dev/go-webui/pull/35

On linux, dirent is always included:
https://github.com/webui-dev/webui/blob/561c0449244f60b7bfdb2b877b17242c238f12e7/include/webui.h#L75-L76