### PR TITLE
Fix condition for release steps when pushing tags

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -127,7 +127,9 @@ jobs:
         with:
           tag_name: nightly
       - name: Release
-        if: github.repository_owner == 'webui-dev' && github.ref_name == 'main' && github.event_name == 'push'
+        if: >
+          github.repository_owner == 'webui-dev'
+          && (github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push'))
         uses: ncipollo/release-action@v1
         with:
           artifacts: ${{ env.ARTIFACT }}.zip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,7 +85,9 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
       - name: Prepare Release
-        if: github.repository_owner == 'webui-dev' && github.ref_name == 'main' && github.event_name == 'push'
+        if: >
+          github.repository_owner == 'webui-dev'
+          && (github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push'))
         run: |
           zip -r "$ARTIFACT.zip" "$ARTIFACT"
           if [ $GITHUB_REF_TYPE == tag ]; then
@@ -106,7 +108,9 @@ jobs:
         with:
           tag_name: nightly
       - name: Release
-        if: github.repository_owner == 'webui-dev' && github.ref_name == 'main' && github.event_name == 'push'
+        if: >
+          github.repository_owner == 'webui-dev'
+          && (github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push'))
         uses: ncipollo/release-action@v1
         with:
           artifacts: ${{ env.ARTIFACT }}.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,7 +93,9 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
       - name: Prepare Release
-        if: github.repository_owner == 'webui-dev' && github.ref_name == 'main' && github.event_name == 'push'
+        if: >
+          github.repository_owner == 'webui-dev'
+          && (github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push'))
         shell: bash
         run: |
           7z a -tzip "$ARTIFACT.zip" "$ARTIFACT/*"
@@ -115,7 +117,9 @@ jobs:
         with:
           tag_name: nightly
       - name: Release
-        if: github.repository_owner == 'webui-dev' && github.ref_name == 'main' && github.event_name == 'push'
+        if: >
+          github.repository_owner == 'webui-dev'
+          && (github.ref_type == 'tag' || (github.ref_name == 'main' && github.event_name == 'push'))
         uses: ncipollo/release-action@v1
         with:
           artifacts: ${{ env.ARTIFACT }}.zip


### PR DESCRIPTION
I simplified the release condition too much with one of the recent updates. We would encounter an issue on the next tag release (I already did in another project after making a similar change).

While creating a tag is a push event, the ref_name is not the branch name like main but the tag's name. So, the condition would be false when it shouldn't be.