### PR TITLE
Fix compiling with swift due to incompatible civetweb structname

### DIFF
--- a/src/civetweb/README.md
+++ b/src/civetweb/README.md
@@ -25,3 +25,8 @@ Changes currently required when updating the submodule to ensure full direct int
   #define snprintf DO_NOT_USE_THIS_FUNCTION__USE_mg_snprintf
   + #endif
   ```
+
+- Allow compiling with swift compiler chaning an incompatible structname
+
+  Rename struct `ah` to `auth_header` [civetweb.c#L8715](https://github.com/webui-dev/webui/blob/ea5540c833b3e4ae38cc8dc7d62965a8507a78ee/src/civetweb/civetweb.c#L8715)
+  In its related code there is also a variable name `auth_header`, make sure to rename it first to prevent conflicts.


### PR DESCRIPTION
The structname `ah` is hindering compilation with swift on macos. 
A fix can be achieved through a simple rename.

I will also make this proposal over at civetweb, as I think the longer name is a better struct name, while `ah` works well for a variable. Though idk if and how long it will take for it to get merged.