### PR TITLE
exposing _webui_get_free_port

### DIFF
--- a/include/webui.h
+++ b/include/webui.h
@@ -708,6 +708,15 @@ WEBUI_EXPORT size_t webui_get_child_process_id(size_t window);
 WEBUI_EXPORT bool webui_set_port(size_t window, size_t port);
 
 /**
+ * @brief Get an available network port to be used by your app or by WebUI.
+ *
+ * @return Returns a free port
+ *
+ * @example int port = _webui_get_free_port(); webui_set_port(myWindow, port);
+ */
+WEBUI_EXPORT size_t _webui_get_free_port(void);
+
+/**
  * @brief Control the WebUI behaviour. It's recommended to be called at the beginning.
  *
  * @param option The desired option from `webui_config` enum

--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -180,6 +180,9 @@ class window {
     // link of `webui.js` in case you are trying to use WebUI with an external web-server like NGNIX
     void set_port(size_t port) const { webui_set_port(webui_window, port); }
 
+    // Get an available network port to be used by your app or by WebUI.
+    size_t get_free_port() { _webui_get_free_port(); }
+
     // Set window position
     void set_position(unsigned int x, unsigned int y) const { webui_set_position(webui_window, x, y); }
 

--- a/src/webui.c
+++ b/src/webui.c
@@ -473,7 +473,7 @@ static void * _webui_run_browser_task(void * _arg);
 static void _webui_init(void);
 static bool _webui_show(_webui_window_t* win, struct mg_connection* client, const char* content, size_t browser);
 static bool _webui_get_cb_index(_webui_window_t* win, const char* element, size_t* id);
-static size_t _webui_get_free_port(void);
+// static size_t _webui_get_free_port(void); // now in headers
 static void _webui_free_port(size_t port);
 static char* _webui_get_current_path(void);
 static void _webui_send_client_ws(_webui_window_t* win, struct mg_connection* client,
@@ -7294,7 +7294,7 @@ static void _webui_free_port(size_t port) {
     }
 }
 
-static size_t _webui_get_free_port(void) {
+size_t _webui_get_free_port(void) {
 
     #ifdef WEBUI_LOG
     printf("[Core]\t\t_webui_get_free_port()\n");


### PR DESCRIPTION
I want to select a port dynamically for my custom web server, and I figured that since the code is already in `webui.c`, just expose it in the headers.

(If this PR is accepted, I have a `zig-webui` PR with an example app.)