### PR TITLE
Remove docs for workarounds for resolved thrid-party conflicts

### DIFF
--- a/src/civetweb/README.md
+++ b/src/civetweb/README.md
@@ -15,18 +15,3 @@ Changes currently required when updating the submodule to ensure full direct int
 
   /* Copyright (c) 2013-2024 the Civetweb developers
   ```
-
-  ```diff
-  + #ifndef NDEBUG
-  #define malloc DO_NOT_USE_THIS_FUNCTION__USE_mg_malloc
-  #define calloc DO_NOT_USE_THIS_FUNCTION__USE_mg_calloc
-  #define realloc DO_NOT_USE_THIS_FUNCTION__USE_mg_realloc
-  #define free DO_NOT_USE_THIS_FUNCTION__USE_mg_free
-  #define snprintf DO_NOT_USE_THIS_FUNCTION__USE_mg_snprintf
-  + #endif
-  ```
-
-- Allow compiling with swift compiler chaning an incompatible structname
-
-  Rename struct `ah` to `auth_header` [civetweb.c#L8715](https://github.com/webui-dev/webui/blob/ea5540c833b3e4ae38cc8dc7d62965a8507a78ee/src/civetweb/civetweb.c#L8715)
-  In its related code there is also a variable name `auth_header`, make sure to rename it first to prevent conflicts.


### PR DESCRIPTION
Both pull request that addressed the conflicts with civetweb were merged. The workarounds are now obsolete and included when updating to latest civetweb.

Related civetweb pulls that contain the changes: \#1261 \#1266