### PR TITLE
Fix release mode building with Zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,9 +68,8 @@ fn addLinkerFlags(b: *Build, webui: *Compile, enable_tls: bool) !void {
     // Prepare compiler flags.
     const tls_flags = &[_][]const u8{ "-DWEBUI_TLS", "-DNO_SSL_DL", "-DOPENSSL_API_1_1" };
     var civetweb_flags = std.ArrayList([]const u8).init(b.allocator);
-    try civetweb_flags.appendSlice(&[_][]const u8{ "-DNDEBUG", "-DNO_CACHING", "-DNO_CGI", "-DUSE_WEBSOCKET" });
+    try civetweb_flags.appendSlice(&[_][]const u8{ "-DNDEBUG", "-DNO_CACHING", "-DNO_CGI", "-DUSE_WEBSOCKET", "-Wno-error=date-time" });
     try civetweb_flags.appendSlice(if (enable_tls) tls_flags else &[_][]const u8{ "-DUSE_WEBSOCKET", "-DNO_SSL" });
-    if (is_windows) try civetweb_flags.append("-DMUST_IMPLEMENT_CLOCK_GETTIME");
 
     webui.addCSourceFile(.{
         .file = if (zig_ver < 12) .{ .path = "src/webui.c" } else b.path("src/webui.c"),


### PR DESCRIPTION
The `build.zig` linker flags setting caused issues with linking `civetweb`, notably redefinition of `MUST_IMPLEMENT_CLOCK_GETTIME` macro and a warning for using the `__DATE__` macro (which turns into an error with default Zig compiler flags). This occurred when attempting to build `webui` with Zig in any release mode on Windows (potentially other OSes as well, but untested).

This patch addresses these issues and allows for building on release modes in at least Windows and Linux systems.