### PR TITLE
Zig build improvements

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -22,15 +22,15 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - name: Build static library
-        run: zig build -Dverbose
+        run: zig build -Dverbose=debug
       - name: Build dynamic library
         if: ${{ !cancelled() }}
-        run: zig build -Ddynamic -Dverbose
+        run: zig build -Ddynamic -Dverbose=debug
       - name: Build static library with TLS support
         if: runner.os == 'Linux'
-        run: zig build -Denable-tls -Dverbose
+        run: zig build -Denable-tls -Dverbose=debug
       - name: Build dynamic library with TLS support
         if: runner.os == 'Linux'
-        run: zig build -Ddynamic -Denable-tls -Dverbose
+        run: zig build -Ddynamic -Denable-tls -Dverbose=debug
       - name: Build examples
         run: zig build examples

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,13 @@
 .{
     .name = "webui",
     .version = "2.5.0-beta.2",
-    .paths = .{""},
+    .paths = .{
+        "src",
+        "include",
+        "bridge",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
 }


### PR DESCRIPTION
Clean up and improvements to current Zig build process. Notably:

1. Specify paths in `build.zig.zon` to limit files stored in cache when `webui` is fetched as a dependency
2. Set `verbose` option to be an enum of levels, so that more specific build information can be emitted 
3. Fix bug where prior `verbose` option printed `Done.` immediately before build process completed
4. General cleanup of linker flags and file paths to adhere to Zig best practices