### PR TITLE
Fix memory error

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -9329,7 +9329,7 @@ static void _webui_ws_process(
 
                             // Check the response
                             if (_webui_is_empty(event_inf->response))
-                                event_inf->response = (char*)"";
+                                event_inf->response = NULL;
 
                             #ifdef WEBUI_LOG
                             printf(

--- a/src/webui.c
+++ b/src/webui.c
@@ -4138,7 +4138,7 @@ static char* _webui_get_file_name_from_url(const char* url) {
     }
 
     // Copy the path to a new string
-    char* file = strdup(pos);
+    char* file = _webui_str_dup(pos);
 
     // Find the position of the first '?'
     char* question_mark = strchr(file, '?');
@@ -4180,9 +4180,6 @@ static char* _webui_get_full_path(_webui_window_t* win, const char* file) {
         }
     }
     #endif
-
-    // Clean
-    _webui_free_mem((void*)file);
 
     #ifdef WEBUI_LOG_VERBOSE
     printf("[Core]\t\t_webui_get_full_path() -> Full path: [%s]\n", full_path);

--- a/src/webui.c
+++ b/src/webui.c
@@ -8854,7 +8854,8 @@ static void _webui_receive(_webui_window_t* win, struct mg_connection* client,
     if (win->ws_block) {
         // Process the packet in this current thread
         _webui_ws_process(win, client, connection_id, arg_ptr, arg_len, ++recvNum, event_type);
-        _webui_free_mem((void*)arg_ptr);
+        if (arg_ptr != data)
+            _webui_free_mem((void*)arg_ptr);
     }
     else {
         // Process the packet in a new thread


### PR DESCRIPTION
- mismatch error,  use strdup() alloc memory, but use _webui_free_mem() to free
- double free error,  _webui_get_full_path() already free 'file' internal, but free again when use
- can't free ws library memory data which not alloced by webui
- can't free const memory