### PR TITLE
fix linux tcc compile fail

### DIFF
--- a/include/webui.h
+++ b/include/webui.h
@@ -20,7 +20,7 @@
 #define WEBUI_MAX_ARG (16)
 
 // Dynamic Library Exports
-#if defined(_MSC_VER) || defined(__TINYC__)
+#if defined(_WIN32) && (defined(_MSC_VER) || defined(__TINYC__))
     #ifndef WEBUI_EXPORT
         #define WEBUI_EXPORT __declspec(dllexport)
     #endif


### PR DESCRIPTION
This PR will fix tcc compile fail error:
```sh
error: declaration for parameter 'webui_new_window' but no such parameter
```
