### PR TITLE
make sure 4096 bytes not alloc 8192 bytes

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -3755,7 +3755,7 @@ static size_t _webui_mb(size_t size) {
     size--;
 
     size_t block_size = 4;
-    while(block_size <= size)
+    while(block_size < size)
         block_size *= 2;
 
     return block_size;


### PR DESCRIPTION
Make sure calling `web_malloc(4096)` will alloc 4096 bytes indeed, not 8192 bytes.
