### PR TITLE
break change: support zig `0.14.0`

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [0.12.0, 0.13.0, '']
+        version: [0.14.0, '']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,6 @@ const Compile = Build.Step.Compile;
 const Module = Build.Module;
 
 const lib_name = "webui";
-const zig_ver = builtin.zig_version.minor;
 var global_log_level: std.log.Level = .warn;
 
 /// Vendored dependencies of webui.
@@ -21,11 +20,6 @@ const DebugDependencies = std.EnumSet(Dependency);
 pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-
-    switch (comptime zig_ver) {
-        12, 13, 14 => {},
-        else => return error.UnsupportedZigVersion,
-    }
 
     const is_dynamic = b.option(bool, "dynamic", "build the dynamic library") orelse false;
     const enable_tls = b.option(bool, "enable-tls", "enable TLS support") orelse false;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "webui",
+    .name = .webui,
     .version = "2.5.0-beta.3",
+    .fingerprint = 0xac5d87f2e5831aa7,
     .paths = .{
         "src",
         "include",


### PR DESCRIPTION
Since this pr, 0.13.0 and previous versions cannot be supported.

`0.14.0` has break change on `build.zig.zon`