### PR TITLE
Remove "index" argument from get_count()

### DIFF
--- a/include/webui.hpp
+++ b/include/webui.hpp
@@ -90,7 +90,7 @@ namespace webui {
             // ------ Event methods `e->xxx()` ------
 
             // Get how many arguments there are in an event.
-            size_t get_count(size_t index = 0) {
+            size_t get_count() {
                 return webui_get_count(this);
             }
 


### PR DESCRIPTION
Argument is not used, I suspect it ended up here as part of an abusive copy-paste!