### PR TITLE
Updates CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ else()
     target_compile_definitions(webui PUBLIC NO_SSL)
 endif()
 
+if (WIN32)
+    target_link_libraries(webui PRIVATE ws2_32 user32 shell32 ole32)
+endif ()
+
 set_target_properties(webui PROPERTIES
     OUTPUT_NAME ${WEBUI_OUT_LIB_NAME}
     PREFIX "")


### PR DESCRIPTION
Fixes #573.

This adds missing Windows system libraries (ws2_32, user32, ole32, shell32) to the webui target when building on Windows. These libraries are required for civetweb.c to link correctly with MinGW, as evidenced by the provided GCC build examples.

This is a temporary workaround.