### PR TITLE
Function webui_maximize should invoke _webui_wv_maximize

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -2846,7 +2846,7 @@ void webui_maximize(size_t window) {
     _webui_window_t* win = _webui.wins[window];
 
     if(win->webView) {
-        _webui_wv_minimize(win->webView);
+        _webui_wv_maximize(win->webView);
     }
 }
 


### PR DESCRIPTION
The `webui_maximize` function currently invokes `_webui_wv_minimize`, which causes the window to minimize rather than maximize.

This seems to be a naming error in the implementation. The expected behavior is for the window to become maximized.

PS: When the window is set to be `transparent` using `webui_set_transparent`, while the window is maximized, click events sometimes fall through the WebUI window and are captured by completely irrelevant windows underneath. This only occurs with transparent mode enabled. I'm using Windows 11 and WebView2 for development.

I believe this is not an intended behavior. It can be a side-effect of transparency in WebView2 on Windows, but it’s quite unexpected.

Would you like me to open a separate issue for this transparency-related behavior?
