### PR TITLE
Update CMake build system and introduce Conan and VCPKG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ CMakeUserPresets.json
 **/conan-*
 **/cmake-build-*
 **/deactivate_conanbuildenv*
+
+# vcpkg
+vcpkg-manifest-install.log
+vcpkg_installed/

--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,11 @@ Thumbs.db
 **/cmake_install.cmake
 **/CMakeCache.txt
 **/CMakeFiles/
+CMakeUserPresets.json
 .zig-cache
+
+# Conan
+**/compressor
+**/conan-*
+**/cmake-build-*
+**/deactivate_conanbuildenv*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 add_library(webui ${SOURCE_FILES})
 target_include_directories(webui PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_compile_definitions(webui PUBLIC NO_CACHING NO_CGI USE_WEBSOCKET 
-    $<$<CONFIG:Debug>:WEBUI_LOG> $<$<CONFIG:Release>:NDEBUG> $<$<CONFIG:MinSizeRel>:NDEBUG>)
+    "$<$<CONFIG:Debug>:WEBUI_LOG>" "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 
 if (BUILD_SHARED_LIBS AND WIN32)
     target_compile_definitions(webui PRIVATE CIVETWEB_DLL_EXPORTS PUBLIC CIVETWEB_DLL_IMPORTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ install(FILES include/webui.h include/webui.hpp DESTINATION include)
 install(TARGETS webui
     EXPORT webui
     ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib)
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
 
 install(EXPORT webui
     FILE webui-config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Project name
-project(WebUILibrary)
+project(WebUILibrary 
+  VERSION 2.5.0
+  DESCRIPTION "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library."
+  HOMEPAGE_URL "https://webui.me/")
 
 # Set C & C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.18)
 
 # Project name
 project(WebUILibrary 
-  VERSION 2.5.0
-  DESCRIPTION "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library."
-  HOMEPAGE_URL "https://webui.me/")
+    VERSION 2.5.0
+    DESCRIPTION "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library."
+    HOMEPAGE_URL "https://webui.me/")
 
 # Set C & C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -18,12 +18,12 @@ set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2")
 # Conditional compilation for TLS
 option(WEBUI_USE_TLS "Enable TLS support" OFF)
 if(WEBUI_USE_TLS)
-  find_package(OpenSSL REQUIRED)
-  set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2-secure")
+    find_package(OpenSSL REQUIRED)
+    set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2-secure")
 endif()
 
 if(NOT BUILD_SHARED_LIBS)
-  set(WEBUI_DEFAULT_OUT_LIB_NAME "${WEBUI_DEFAULT_OUT_LIB_NAME}-static")
+    set(WEBUI_DEFAULT_OUT_LIB_NAME "${WEBUI_DEFAULT_OUT_LIB_NAME}-static")
 endif()
 
 # Output library name
@@ -34,6 +34,12 @@ set(SOURCE_FILES
     src/civetweb/civetweb.c
     src/webui.c
 )
+if (APPLE)
+    # enable macos webview
+    enable_language(OBJC)
+    set(CMAKE_OBJC_STANDARD 11)
+    list(APPEND SOURCE_FILES src/webview/wkwebview.m)
+endif()
 
 # Library targets
 add_library(webui ${SOURCE_FILES})
@@ -53,7 +59,13 @@ endif()
 
 if (WIN32)
     target_link_libraries(webui PRIVATE ws2_32 user32 shell32 ole32)
-endif ()
+elseif(APPLE)
+    # link required frameworks
+    find_library(COCOA_FRAMEWORK Cocoa REQUIRED)
+    find_library(WEBKIT_FRAMEWORK WebKit REQUIRED)
+
+    target_link_libraries(webui PRIVATE ${COCOA_FRAMEWORK} ${WEBKIT_FRAMEWORK})
+endif()
 
 set_target_properties(webui PROPERTIES
     OUTPUT_NAME ${WEBUI_OUT_LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,11 @@ cmake_minimum_required(VERSION 3.10)
 # Project name
 project(WebUILibrary)
 
-# Set C++ standard
+# Set C & C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Variables for library names, source files, etc.
 set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,12 @@ set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2")
 
 # Conditional compilation for TLS
 option(WEBUI_USE_TLS "Enable TLS support" OFF)
-if(WEBUI_USE_TLS)
+if (WEBUI_USE_TLS)
     find_package(OpenSSL REQUIRED)
     set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2-secure")
 endif()
 
-if(NOT BUILD_SHARED_LIBS)
+if (NOT BUILD_SHARED_LIBS)
     set(WEBUI_DEFAULT_OUT_LIB_NAME "${WEBUI_DEFAULT_OUT_LIB_NAME}-static")
 endif()
 
@@ -44,13 +44,14 @@ endif()
 # Library targets
 add_library(webui ${SOURCE_FILES})
 target_include_directories(webui PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
-target_compile_definitions(webui PUBLIC NDEBUG NO_CACHING NO_CGI USE_WEBSOCKET)
+target_compile_definitions(webui PUBLIC NO_CACHING NO_CGI USE_WEBSOCKET 
+    $<$<CONFIG:Debug>:WEBUI_LOG> $<$<CONFIG:Release>:NDEBUG> $<$<CONFIG:MinSizeRel>:NDEBUG>)
 
-if(BUILD_SHARED_LIBS AND WIN32)
+if (BUILD_SHARED_LIBS AND WIN32)
     target_compile_definitions(webui PRIVATE CIVETWEB_DLL_EXPORTS PUBLIC CIVETWEB_DLL_IMPORTS)
 endif()
 
-if(WEBUI_USE_TLS)
+if (WEBUI_USE_TLS)
     target_compile_definitions(webui PUBLIC WEBUI_TLS NO_SSL_DL OPENSSL_API_1_1)
     target_link_libraries(webui PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 else()
@@ -59,7 +60,7 @@ endif()
 
 if (WIN32)
     target_link_libraries(webui PRIVATE ws2_32 user32 shell32 ole32)
-elseif(APPLE)
+elseif (APPLE)
     # link required frameworks
     find_library(COCOA_FRAMEWORK Cocoa REQUIRED)
     find_library(WEBKIT_FRAMEWORK WebKit REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,21 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Variables for library names, source files, etc.
-set(WEBUI_OUT_LIB_NAME "webui-2")
+set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2")
 
 # Conditional compilation for TLS
 option(WEBUI_USE_TLS "Enable TLS support" OFF)
 if(WEBUI_USE_TLS)
   find_package(OpenSSL REQUIRED)
-  set(WEBUI_OUT_LIB_NAME "webui-2-secure")
+  set(WEBUI_DEFAULT_OUT_LIB_NAME "webui-2-secure")
 endif()
+
+if(NOT BUILD_SHARED_LIBS)
+  set(WEBUI_DEFAULT_OUT_LIB_NAME "${WEBUI_DEFAULT_OUT_LIB_NAME}-static")
+endif()
+
+# Output library name
+set(WEBUI_OUT_LIB_NAME "${WEBUI_DEFAULT_OUT_LIB_NAME}" CACHE STRING "Name of the output library")
 
 # Source files (already filled)
 set(SOURCE_FILES
@@ -44,8 +51,7 @@ if (WIN32)
 endif ()
 
 set_target_properties(webui PROPERTIES
-    OUTPUT_NAME ${WEBUI_OUT_LIB_NAME}
-    PREFIX "")
+    OUTPUT_NAME ${WEBUI_OUT_LIB_NAME})
 
 # Install headers
 install(FILES include/webui.h include/webui.hpp DESTINATION include)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,33 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+
+class WebuiConan(ConanFile):
+    name = "webui"
+    version = "2.5.0-beta.4"
+    license = "MIT"
+    url = "https://github.com/webui-dev/webui"
+    homepage = "https://webui.me"
+    description = "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library."
+
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"tls": [True, False], "shared": [True, False]}
+    default_options = {"tls": False, "shared": False}
+
+    generators = "CMakeDeps"
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WEBUI_USE_TLS"] = self.options.tls
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def requirements(self):
+        self.tool_requires("cmake/[>=3.18.0]")
+
+        if self.options.tls:
+            self.requires("openssl/[>3.0.0]")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "webui",
+  "version": "2.5.0-beta.4",
+  "description": "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library.",
+  "license": "MIT",
+  "homepage": "https://webui.me",
+  "dependencies": [
+    {
+      "name": "webview2",
+      "platform": "windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tls": {
+      "description": "Enable TLS support",
+      "dependencies": [{
+        "name": "openssl",
+        "version>=": "3.0.0"
+      }]
+    }
+  }
+}


### PR DESCRIPTION
This updates the CMake build system to have more features and introduces both [Conan](https://conan.io) and [VCPKG](https://vcpkg.io) in order to support easier fetching of dependencies (OpenSSL and WebView2)

The changes made to the CMake itself are:
- Added metadata like version and description
- Explicitely defined C version as 99
- Add `WEBUI_LOG` and `NDEBUG` flags depending on configurarion (like build.zig or makefiles)
- Add the 'lib' prefix on macOS and Linux (parity with makefile behaviour)
- Allow the user to change the output library name (webui by default uses different names, e.g. -static, -secure, when building, this allows the user to remove those if desired)
- Fix dll not getting copied when installing (added runtime install directive)
- Add support for building ObjC on macOS (webview)

### Conan and VCPKG
Conan and VCPKG are both package managers used for C and C++. Here I included them to automatically download and build OpenSSL, this makes it trivial to build webui with OpenSSL support without having an OpenSSL dev environment installed.

Using Conan it's just `conan build . -of build -o tls=True`. If Conan and a compiler environment are installed this will do the following:
- Download CMake
- Download and build OpenSSL
- Configure webui based on Conan options
- Build and link webui

With VCPKG the process is more complicated but you also have more granular control about it (e.g. cross compiling), it more or less boiles down to

1. `vcpkg install --x-feature=tls` which will download and build OpenSSL
2. `cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=<vcpkg_install_dir>\scripts\buildsystems\vcpkg.cmake -DWEBUI_USE_TLS=ON`
3. `cmake --build build`

This will result in more or less the same result as the Conan command.
Additionally VCPKG will download WebView2, however, since webui doesn't link against it but rather load the dll dynamically the user still needs to copy it manually, changing this _could_ probably be possible using a newer CMake version but I didn't look into it too deep.

Note that neither Conan nor VCPKG are included in their package forms but only for building webui itself. This is because Conan's package format is (in my opinion) a bit confusing and VCPKG's packages are mostly managed in a central repo by Microsoft (which already includes a webui package).
