### PR TITLE
fix check event_data size error when event_data start with 0x0

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -1975,7 +1975,7 @@ const char* webui_get_string_at(webui_event_t* e, size_t index) {
         return NULL;
 
     if (event_inf->event_data[index] != NULL) {
-        size_t len = _webui_strlen(event_inf->event_data[index]);
+        size_t len = _event_inf->event_size[index];
         if (len > 0 && len <= WEBUI_MAX_BUF)
             return (const char*)event_inf->event_data[index];
     }


### PR DESCRIPTION
use `event_inf->event_size[index]` instead of `_webui_strlen(event_inf->event_data[index])`， to avoid this error.