### PR TITLE
Fix mutex unlock in _webui_free_all_mem

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -4346,8 +4346,10 @@ static void _webui_free_all_mem(void) {
 
     // Makes sure we run this once
     static bool freed = false;
-    if (freed)
+    if (freed) {
+        _webui_mutex_unlock(&_webui.mutex_mem);
         return;
+    }
     freed = true;
 
     // Free all pointers in the list


### PR DESCRIPTION
## Summary
- prevent leaking the memory management mutex when `_webui_free_all_mem` is called after it has already run
- compile `webui.c` and `civetweb.c` to ensure build works without TLS

## Testing
- `gcc -DNO_SSL -Iinclude -c src/webui.c src/civetweb/civetweb.c`

------
https://chatgpt.com/codex/tasks/task_e_688cef784bbc8320ac63e69affd88ca9