### PR TITLE
Win32 - Fix uninitialized vars

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -11728,6 +11728,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         // Window class
         const char wvClass[] = "WebViewWindow";
         WNDCLASSA wc;
+        ZeroMemory(&wc, sizeof(WNDCLASSA));
         wc.lpfnWndProc = WndProc;
         wc.hInstance = GetModuleHandle(NULL);
         wc.lpszClassName = wvClass;


### PR DESCRIPTION
Fix uninitialized variable on Windows.

`wc.lpszMenuName` is not assigned, and will crash when `RegisterClassA`.