### PR TITLE
Array too small (MAX_BROWSER_FILES)

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -6080,11 +6080,6 @@ static bool _webui_custom_browser_exist(_webui_window_t* win, size_t browser) {
     #define MAX_BROWSER_FILES (5)
     char* executable = NULL;
     char* executables[MAX_BROWSER_FILES] = {0};
-    {
-        int i;
-        for(i = 0; i < MAX_BROWSER_FILES; i++)
-            executables[i] = NULL;
-    }
     if (browser == Chrome) {
         executables[0] = "google-chrome";
         executables[1] = "google-chrome-stable";


### PR DESCRIPTION
Fixed problem with array allocation for executables array.
MAX_BROWSER_FILES needed to be 5. Also initialized all
array entries to NULL before assigning executable names.