### PR TITLE
Fix endless recursion on webui_malloc in debug mode.

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -739,7 +739,7 @@ static void _webui_log(size_t level, const char *format, va_list args) {
             return;
         }
         vsnprintf(buffer, needed_size + 1, format, args);
-        _webui_log_data.logger_func(level, buffer, _webui.logger_user_data);
+        _webui_log_data.logger_func(level, buffer, _webui_log_data.logger_user_data);
         if (buffer != buf) _webui_free_mem((void*)buffer);
     }
 }


### PR DESCRIPTION
Fix endless recursion on webui_malloc in debug mode.
We're sure the length of the debug message of _webui_malloc < 256, 
so in that case we have enough room to print the debug message 
without allocating memory with _webui_malloc, which prevents 
an endless recursion to _webui_log.