### PR TITLE
So, I think this is a minimal solution to this GtkWebkit WebView navigation problem

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -12338,8 +12338,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
 
         // Linux GTK WebView
 
-        GTK_WEBVIEW_SET_IN_SHOW(win, true)
-
         #ifdef WEBUI_DYNAMIC
         #ifdef WEBUI_LOG
         _webui_log_debug("[Core]\t\t_webui_wv_show() -> WebUI dynamic version does not support Linux WebView\n");


### PR DESCRIPTION
By debugging I learned that the webView structure is initially not created. 
Only further on in the process there will be a webView structure that can be checked for. 

Hence  the statement at line 12140 was only necessary, because before that there was no webView structure to set variable `in_show` to true. 

Because of this I moved the `in_show` attribute to the `_webui_window_t`. That will always be there.  Only when on linux though. 

Now the only place to set in_show to true is at the beginning of `_webui_show_window`, before all other processing begins. 



