### PR TITLE
Fix for UTF-8 problems with the ascii printer.

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -666,7 +666,7 @@ static bool _webui_check_certificate(const char* certificate_pem, const char* pr
 #endif
 #ifdef WEBUI_LOG
 static void _webui_print_hex(const char* data, size_t len);
-static void (const char* data, size_t len);
+static void _webui_print_ascii(const char* data, size_t len);
 static int _webui_http_log(const struct mg_connection* client, const char* message);
 #endif
 static WEBUI_THREAD_SERVER_START;


### PR DESCRIPTION
Characters need to be in the ascii range, otherwise invalid UTF-8 data can (and is) written.

So anything outside the 32-126 range is output as hexadecimal number.