### PR TITLE
Fix Windows WebView icon fallback to use executable icon

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -12804,8 +12804,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
         wc.cbClsExtra = 0;
         wc.cbWndExtra = 0;
-        wc.hIcon = LoadIcon(GetModuleHandle(NULL) ,MAKEINTRESOURCE(101));    // default user icon resouce : 101
-        if(!wc.hIcon) wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);            // if not existed, use system default icon
+        wc.hIcon = LoadIcon(wc.hInstance, MAKEINTRESOURCE(101));            // default user icon resource: 101
+        if (!wc.hIcon) wc.hIcon = LoadIcon(wc.hInstance, IDI_APPLICATION);  // otherwise, use the executable's application icon
+        if (!wc.hIcon) wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);          // if not present, use the system default icon
 
         if (!RegisterClassA(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
             _webui_wv_free(win->webView);


### PR DESCRIPTION
Fixes #708

## Summary

Improve the Windows WebView window-icon fallback sequence:

1. Preserve the existing custom icon resource ID 101.
2. Fall back to the executable’s `IDI_APPLICATION` resource.
3. Fall back to the generic Windows application icon only when neither executable resource exists.

## Motivation

WebUI currently loads resource 101 and then immediately uses the generic system icon when that resource is absent.

Windows applications commonly store their executable application icon under `IDI_APPLICATION` (resource 32512). As a result, an executable can be correctly branded in Explorer while its WebUI window, taskbar button, caption, and Alt+Tab entry display the generic icon.

Using `wc.hInstance` with `IDI_APPLICATION` loads the resource from the executable. The existing `LoadIcon(NULL, IDI_APPLICATION)` call remains the final system fallback.

## Compatibility

- Existing applications using resource 101 retain precedence.
- Applications using `IDI_APPLICATION` now receive their embedded icon.
- Applications without either resource continue to receive the generic system icon.
- No public API or ABI changes are introduced.
- The change only affects the Windows embedded WebView implementation.

## Testing

Built successfully on Windows with MSVC as:

- A shared WebUI DLL
- A static WebUI library with `WEBUI_WEBVIEW_STATIC`